### PR TITLE
Resolve Oddities in the UI

### DIFF
--- a/client/main.tsx
+++ b/client/main.tsx
@@ -16,7 +16,13 @@ import { LoginForm } from '../imports/ui/LoginForm';
 const App: React.FC = () => {
   const user = useTracker(() => Meteor.user());
   const loggingIn = useTracker(() => Meteor.loggingIn());
-  if (loggingIn) {
+  // userId is read from localStorage synchronously — available immediately on
+  // refresh before DDP has reconnected and fetched the full user document.
+  // If userId exists but user is null, we're in the reconnect window: show a
+  // loading state instead of the login form to prevent the flash of login screen.
+  const userId = useTracker(() => Meteor.userId());
+
+  if (loggingIn || (userId && !user)) {
     return (
       <div className="flex min-h-screen items-center justify-center bg-neutral-100 dark:bg-neutral-900">
         <p className="text-sm text-neutral-600 dark:text-neutral-300">Loading…</p>

--- a/imports/startup/ssr.tsx
+++ b/imports/startup/ssr.tsx
@@ -19,8 +19,6 @@ import React from 'react';
 import { renderToString } from 'react-dom/server';
 
 import { REPO_URL } from '../lib/constants';
-import { LandingPage } from '../ui/LandingPage';
-import { LoginForm } from '../ui/LoginForm';
 
 // ─── Static SEO content ───────────────────────────────────────────────────────
 
@@ -149,23 +147,24 @@ onPageLoad((sink) => {
   const { pathname, query } = extractUrl(req?.url);
 
   if (pathname === '/' || pathname.startsWith('/app')) {
-    // ── App routes: SSR the login form ─────────────────────────────────────
-    // Unauthenticated visitors see the LoginForm. Authenticated users
-    // will be swapped to AppLayout after hydration on the client.
-    const mode = query.mode === 'signup' ? 'signup' : 'login';
-    try {
-      const html = renderToString(<LoginForm initialMode={mode} />);
-      sink.appendToHead(
-        buildHeadTags(mode === 'signup' ? '<meta name="robots" content="index,follow" />' : ''),
-      );
-      sink.appendToBody(`<div id="root">${html}</div>`);
-    } catch (err) {
-      console.error('[SSR] LoginForm renderToString failed:', err);
-      sink.appendToHead(
-        [`<title>${esc(PAGE_TITLE)}</title>`, `<script>${THEME_INIT_SCRIPT}</script>`].join('\n'),
-      );
-      sink.appendToBody('<div id="root"></div>');
-    }
+    // ── App routes: SSR a loading state ────────────────────────────────────
+    // The server cannot know if the visitor is authenticated, so we no longer
+    // pre-render the LoginForm here. Sending LoginForm HTML caused a visible
+    // flash for authenticated users on refresh: the browser painted the form
+    // before JavaScript loaded and could swap to AppLayout.
+    //
+    // Instead we render the same loading placeholder that the client shows
+    // while Meteor's DDP connection re-establishes. Authenticated users see a
+    // seamless loading → app transition; unauthenticated users see a brief
+    // loading spinner before the LoginForm appears.
+    const loadingHtml =
+      '<div class="flex min-h-screen items-center justify-center bg-neutral-100 dark:bg-neutral-900">' +
+      '<p class="text-sm text-neutral-600 dark:text-neutral-300">Loading\u2026</p>' +
+      '</div>';
+    sink.appendToHead(
+      [`<title>${esc(PAGE_TITLE)}</title>`, `<script>${THEME_INIT_SCRIPT}</script>`].join('\n'),
+    );
+    sink.appendToBody(`<div id="root">${loadingHtml}</div>`);
   } else {
     // ── Unknown routes: plain shell ────────────────────────────────────────
     sink.appendToHead(

--- a/imports/ui/AppLayout.tsx
+++ b/imports/ui/AppLayout.tsx
@@ -23,6 +23,7 @@ import { TeamsPage } from '../features/teams/TeamsPage';
 import { TicketsPage } from '../features/tickets/TicketsPage';
 import { SIDEBAR_KEY } from '../lib/constants';
 import { TeamProvider } from '../lib/TeamContext';
+import { useBrand } from '../lib/useBrand';
 import { AppHeader } from './AppHeader';
 import { RouterContext } from './router';
 import { SettingsPage } from './SettingsPage';
@@ -79,6 +80,8 @@ export const useSidebar = () => useContext(SidebarContext);
 // ─── AppLayout ────────────────────────────────────────────────────────────────
 
 export const AppLayout: React.FC = () => {
+  // Apply the saved brand/color theme on every mount, not just on SettingsPage
+  useBrand();
   // ── Routing ──
   // Normalize legacy /app root to /app/todos so the sidebar item is always active
   const normalizePath = (p: string) => (p === '/app' ? '/app/dashboard' : p);

--- a/imports/ui/LoginForm.tsx
+++ b/imports/ui/LoginForm.tsx
@@ -1,4 +1,3 @@
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import {
   faBolt,
   faClock,
@@ -12,7 +11,6 @@ import { Accounts } from 'meteor/accounts-base';
 import { Meteor } from 'meteor/meteor';
 import React, { useEffect, useState } from 'react';
 
-import { REPO_URL } from '../lib/constants';
 import { useMethod } from '../lib/useMethod';
 import { Button, Input, Text } from '@mieweb/ui';
 import { ThemeToggle } from './ThemeToggle';
@@ -217,15 +215,6 @@ export const LoginForm: React.FC<LoginFormProps> = ({ initialMode }) => {
       <div className="relative flex w-full flex-col items-center justify-center px-6 py-12 md:w-1/2 md:px-12 lg:px-20">
         {/* Top bar */}
         <div className="absolute right-4 top-4 flex items-center gap-2">
-          <a
-            href={REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            aria-label="View source on GitHub"
-            className="flex h-8 w-8 items-center justify-center rounded-md border border-neutral-300 bg-white text-neutral-600 shadow-sm transition-colors hover:bg-neutral-100 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-300 dark:hover:bg-neutral-700"
-          >
-            <FontAwesomeIcon icon={faGithub} className="text-base" />
-          </a>
           <ThemeToggle />
         </div>
 

--- a/imports/ui/SettingsPage.tsx
+++ b/imports/ui/SettingsPage.tsx
@@ -32,7 +32,6 @@ import { Meteor } from 'meteor/meteor';
 import { useTracker } from 'meteor/react-meteor-data';
 import React, { useState, useCallback } from 'react';
 
-import { REPO_URL } from '../lib/constants';
 import { useBrand, BRANDS } from '../lib/useBrand';
 import { useMethod } from '../lib/useMethod';
 import { useTheme } from '../lib/useTheme';
@@ -232,16 +231,7 @@ export const SettingsPage: React.FC = () => {
             <Badge variant="outline">{version}</Badge>
           </Row>
         ))}
-        <Row label="Source code">
-          <a
-            href={REPO_URL}
-            target="_blank"
-            rel="noopener noreferrer"
-            className="text-sm text-blue-600 underline underline-offset-2 hover:text-blue-500 dark:text-blue-400"
-          >
-            GitHub ↗
-          </a>
-        </Row>
+
       </Section>
     </div>
   );

--- a/imports/ui/Sidebar.tsx
+++ b/imports/ui/Sidebar.tsx
@@ -9,7 +9,6 @@
  *
  * Labels fade in/out with AnimatePresence so they never clip during resize.
  */
-import { faGithub } from '@fortawesome/free-brands-svg-icons';
 import {
   faChevronLeft,
   faChevronRight,
@@ -26,7 +25,6 @@ import { Button } from '@mieweb/ui';
 import { AnimatePresence, motion } from 'motion/react';
 import React from 'react';
 
-import { REPO_URL } from '../lib/constants';
 import { useSidebar } from './AppLayout';
 import { useRouter } from './router';
 
@@ -196,34 +194,6 @@ const SidebarContent: React.FC = () => {
 
       {/* Footer */}
       <div className="shrink-0 space-y-0.5 border-t border-neutral-200 px-2 py-3 dark:border-neutral-800">
-        {/* GitHub link */}
-        <a
-          href={REPO_URL}
-          target="_blank"
-          rel="noopener noreferrer"
-          title={!isExpanded ? 'View on GitHub' : undefined}
-          className={[
-            'flex h-9 items-center rounded-lg text-sm text-neutral-500 transition-colors hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800',
-            isExpanded ? 'gap-3 px-2.5' : 'w-full justify-center px-0',
-          ].join(' ')}
-        >
-          <FontAwesomeIcon icon={faGithub} className="w-4 shrink-0 text-sm" />
-          <AnimatePresence initial={false}>
-            {isExpanded && (
-              <motion.span
-                key="github-label"
-                initial={{ opacity: 0, width: 0 }}
-                animate={{ opacity: 1, width: 'auto' }}
-                exit={{ opacity: 0, width: 0 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
-                className="overflow-hidden whitespace-nowrap"
-              >
-                GitHub
-              </motion.span>
-            )}
-          </AnimatePresence>
-        </a>
-
         {/* Collapse toggle */}
         <button
           type="button"


### PR DESCRIPTION
useBrand() was only called inside SettingsPage, so the brand CSS was never injected unless the user navigated there. Moving the call to AppLayout ensures the saved brand is applied on every page load.

**Also**: prevents rendering the login/landing page if already logged in when 1) refreshing with the browser, or URL hacking to `/` or `/app` directly.

**Also**: Removes un-related github links to the prettier project

Fixes #21
Fixes #19
Fixes #18 