### PR TITLE
fix: serve built dist via vite preview with correct PM2 CWD

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,7 +120,8 @@ jobs:
             npm run build
 
             echo "🚀 Restarting PM2..."
-            sudo pm2 restart all --update-env
+            sudo pm2 delete timehuddle-frontend 2>/dev/null || true
+            sudo pm2 start npm --name timehuddle-frontend --cwd "$REPO_DIR" -- run preview
             sudo pm2 save
 
             echo "⏳ Waiting for process to stabilize..."


### PR DESCRIPTION
Bug: CI was restarting PM2 without specifying CWD so it kept running vite dev from pdharamkar home dir instead of root's built dist. Fix: delete+recreate PM2 process with explicit CWD and `npm run preview` to serve the built `dist/`.