### PR TITLE
fix: allow all hosts in vite preview for deployed environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     port: 3000,
   },
 
+  preview: {
+    allowedHosts: true,
+  },
+
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
vite preview blocks requests from non-localhost hostnames by default (security feature). Add preview.allowedHosts: true so the deployed server accepts requests with the external hostname.