### PR TITLE
fix: allow all hosts in vite dev server for deployed environment

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -14,6 +14,7 @@ export default defineConfig({
 
   server: {
     port: 3000,
+    allowedHosts: true,
   },
 
   preview: {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -16,6 +16,10 @@ export default defineConfig({
     port: 3000,
   },
 
+  preview: {
+    allowedHosts: true,
+  },
+
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
Adds `allowedHosts: true` to the vite `server` config (dev server) to match the existing `preview` config, so the dev server also works behind reverse proxies in deployed environments.