### PR TITLE
fix: remove duplicate preview key in vite.config.ts

### DIFF
--- a/vite.config.ts
+++ b/vite.config.ts
@@ -21,10 +21,6 @@ export default defineConfig({
     allowedHosts: true,
   },
 
-  preview: {
-    allowedHosts: true,
-  },
-
   build: {
     outDir: 'dist',
     sourcemap: true,


### PR DESCRIPTION
Removes the duplicate `preview` block introduced by the merge of #48 into #47.