### PR TITLE
UI: Only Use Full Width Layout on Work & Tickets Pages

### DIFF
--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -632,7 +632,7 @@ export const TicketsPage: React.FC = () => {
   }
 
   return (
-    <AppPage>
+    <AppPage fullWidth>
       {/* ── Header: New Ticket + Search ── */}
       <div className="flex flex-wrap items-center gap-3">
         <Button

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -489,7 +489,7 @@ export const WorkPage: React.FC = () => {
   }
 
   return (
-    <AppPage>
+    <AppPage fullWidth>
       {/* ── Page Header: week nav + today + week range ── */}
       <div className="flex items-center justify-between gap-3">
         <Text weight="semibold" className="truncate">

--- a/src/ui/AppPage.tsx
+++ b/src/ui/AppPage.tsx
@@ -1,8 +1,8 @@
 /**
  * AppPage — Shared layout wrapper for all authenticated app route pages.
  *
- * Centralises top-level padding, spacing, and page-heading structure so that
- * every route renders consistently without per-page boilerplate.
+ * Centralises top-level padding, spacing, max content width (md:max-w-4xl
+ * centered), and page-heading structure so routes render consistently.
  *
  * Intentionally minimal: no routing, no auth, no context reads.
  */
@@ -13,6 +13,11 @@ interface AppPageProps {
   subtitle?: string;
   children: React.ReactNode;
   /**
+   * When true, skip the default content max-width (full main column width).
+   * Use for dense data views (e.g. tickets table, work timers).
+   */
+  fullWidth?: boolean;
+  /**
    * Optional extra classes applied to the outer wrapper div.
    * Use sparingly — only for pages that require a non-standard layout
    * (e.g. full-height flex containers for chat/canvas interfaces).
@@ -20,8 +25,17 @@ interface AppPageProps {
   className?: string;
 }
 
-export const AppPage: React.FC<AppPageProps> = ({ subtitle, children, className }) => (
-  <div className={`w-full space-y-6 p-4 md:p-6${className ? ` ${className}` : ''}`}>
+export const AppPage: React.FC<AppPageProps> = ({
+  subtitle,
+  children,
+  className,
+  fullWidth,
+}) => (
+  <div
+    className={`w-full space-y-6 p-4 md:p-6${
+      fullWidth ? '' : ' md:mx-auto md:max-w-4xl'
+    }${className ? ` ${className}` : ''}`}
+  >
     {subtitle && <p className="text-sm text-neutral-500 dark:text-neutral-400">{subtitle}</p>}
     {children}
   </div>

--- a/src/ui/AppPage.tsx
+++ b/src/ui/AppPage.tsx
@@ -25,12 +25,7 @@ interface AppPageProps {
   className?: string;
 }
 
-export const AppPage: React.FC<AppPageProps> = ({
-  subtitle,
-  children,
-  className,
-  fullWidth,
-}) => (
+export const AppPage: React.FC<AppPageProps> = ({ subtitle, children, className, fullWidth }) => (
   <div
     className={`w-full space-y-6 p-4 md:p-6${
       fullWidth ? '' : ' md:mx-auto md:max-w-4xl'

--- a/src/ui/SettingsPage.tsx
+++ b/src/ui/SettingsPage.tsx
@@ -57,18 +57,18 @@ const Section: React.FC<{
   children: React.ReactNode;
 }> = ({ icon, title, description, children }) => (
   <Card padding="none">
-    <CardHeader className="flex items-start gap-3 px-5 py-4">
-      <div className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
-        <FontAwesomeIcon icon={icon} className="text-sm" />
-      </div>
-      <div>
+    <CardHeader className="flex flex-col gap-0 px-5 py-4">
+      <div className="flex flex-row items-center gap-3">
+        <div className="flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400">
+          <FontAwesomeIcon icon={icon} className="text-sm" />
+        </div>
         <CardTitle className="text-sm">{title}</CardTitle>
-        {description && (
-          <Text variant="muted" size="xs" className="mt-0.5">
-            {description}
-          </Text>
-        )}
       </div>
+      {description && (
+        <Text variant="muted" size="xs" className="pl-11">
+          {description}
+        </Text>
+      )}
     </CardHeader>
     <CardContent className="divide-y divide-neutral-100 p-0 dark:divide-neutral-800">
       {children}


### PR DESCRIPTION
Updated the design. 

<img width="1964" height="973" alt="Image" src="https://github.com/user-attachments/assets/90fb67ca-3518-4b51-abbc-ea95706cdd48" />