### PR TITLE
fix(ui): full labels in mobile nav drawer, hide rail collapse

### DIFF
--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -1,13 +1,15 @@
 /**
  * Sidebar — Collapsible app navigation.
  *
- * Desktop: fixed width panel, animates between 240 px (expanded) and
- * 64 px (collapsed / icon-only) using a spring.
+ * Desktop rail (md+): fixed width panel, animates between 240 px (expanded) and
+ * 64 px (collapsed / icon-only) using a spring. Collapse control lives in the
+ * rail footer.
  *
- * Mobile (< md): hidden by default; slides in as a full-height drawer from
- * the left when isMobileOpen is true in SidebarContext.
+ * Mobile drawer (< md): slides in from the left when isMobileOpen is true.
+ * The drawer always shows icons with labels (never icon-only) and does not
+ * show the rail collapse control — the hamburger/drawer is the primary pattern.
  *
- * Labels fade in/out with AnimatePresence so they never clip during resize.
+ * Labels fade in/out with AnimatePresence on the rail so they never clip during resize.
  */
 import {
   faChevronLeft,
@@ -88,6 +90,12 @@ const NAV: NavSection[] = [
   },
 ];
 
+type SidebarContentVariant = 'rail' | 'drawer';
+
+interface SidebarContentProps {
+  variant?: SidebarContentVariant;
+}
+
 // ─── NavLink ─────────────────────────────────────────────────────────────────
 
 const NavLink: React.FC<{ item: NavItem; active: boolean; expanded: boolean }> = ({
@@ -144,9 +152,10 @@ const NavLink: React.FC<{ item: NavItem; active: boolean; expanded: boolean }> =
 
 // ─── SidebarContent ───────────────────────────────────────────────────────────
 
-const SidebarContent: React.FC = () => {
+const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => {
   const { isExpanded, toggle } = useSidebar();
   const { pathname } = useRouter();
+  const expanded = variant === 'drawer' ? true : isExpanded;
 
   return (
     <div className="flex h-full flex-col">
@@ -154,7 +163,7 @@ const SidebarContent: React.FC = () => {
       <div
         className={[
           'sidebar-brand flex shrink-0 items-center border-b border-neutral-200 px-3 dark:border-neutral-800',
-          isExpanded ? '' : 'justify-center',
+          expanded ? '' : 'justify-center',
         ].join(' ')}
         style={{ minHeight: '4rem' }}
       >
@@ -166,7 +175,7 @@ const SidebarContent: React.FC = () => {
           </div>
           {/* Wordmark */}
           <AnimatePresence initial={false}>
-            {isExpanded && (
+            {expanded && (
               <motion.div
                 key="wordmark"
                 initial={{ opacity: 0, width: 0 }}
@@ -193,7 +202,7 @@ const SidebarContent: React.FC = () => {
           <div key={si}>
             {/* Section heading — only shown when expanded */}
             <AnimatePresence initial={false}>
-              {isExpanded && section.heading && (
+              {expanded && section.heading && (
                 <motion.p
                   key="heading"
                   initial={{ opacity: 0, height: 0 }}
@@ -209,7 +218,7 @@ const SidebarContent: React.FC = () => {
             <ul className="space-y-0.5">
               {section.items.map((item) => (
                 <li key={item.label}>
-                  <NavLink item={item} active={pathname === item.href} expanded={isExpanded} />
+                  <NavLink item={item} active={pathname === item.href} expanded={expanded} />
                 </li>
               ))}
             </ul>
@@ -217,39 +226,39 @@ const SidebarContent: React.FC = () => {
         ))}
       </nav>
 
-      {/* Footer */}
-      <div className="shrink-0 space-y-0.5 border-t border-neutral-200 px-2 py-3 dark:border-neutral-800">
-        {/* Collapse toggle */}
-        <button
-          type="button"
-          onClick={toggle}
-          title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-          aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
-          className={[
-            'flex h-9 w-full items-center rounded-lg text-sm text-neutral-500 transition-colors hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800',
-            isExpanded ? 'gap-3 px-2.5' : 'justify-center px-0',
-          ].join(' ')}
-        >
-          <FontAwesomeIcon
-            icon={isExpanded ? faChevronLeft : faChevronRight}
-            className="w-4 shrink-0 text-xs"
-          />
-          <AnimatePresence initial={false}>
-            {isExpanded && (
-              <motion.span
-                key="collapse-label"
-                initial={{ opacity: 0, width: 0 }}
-                animate={{ opacity: 1, width: 'auto' }}
-                exit={{ opacity: 0, width: 0 }}
-                transition={{ duration: 0.15, ease: 'easeInOut' }}
-                className="overflow-hidden whitespace-nowrap"
-              >
-                Collapse
-              </motion.span>
-            )}
-          </AnimatePresence>
-        </button>
-      </div>
+      {variant === 'rail' && (
+        <div className="shrink-0 space-y-0.5 border-t border-neutral-200 px-2 py-3 dark:border-neutral-800">
+          <button
+            type="button"
+            onClick={toggle}
+            title={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+            aria-label={isExpanded ? 'Collapse sidebar' : 'Expand sidebar'}
+            className={[
+              'flex h-9 w-full items-center rounded-lg text-sm text-neutral-500 transition-colors hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800',
+              isExpanded ? 'gap-3 px-2.5' : 'justify-center px-0',
+            ].join(' ')}
+          >
+            <FontAwesomeIcon
+              icon={isExpanded ? faChevronLeft : faChevronRight}
+              className="w-4 shrink-0 text-xs"
+            />
+            <AnimatePresence initial={false}>
+              {isExpanded && (
+                <motion.span
+                  key="collapse-label"
+                  initial={{ opacity: 0, width: 0 }}
+                  animate={{ opacity: 1, width: 'auto' }}
+                  exit={{ opacity: 0, width: 0 }}
+                  transition={{ duration: 0.15, ease: 'easeInOut' }}
+                  className="overflow-hidden whitespace-nowrap"
+                >
+                  Collapse
+                </motion.span>
+              )}
+            </AnimatePresence>
+          </button>
+        </div>
+      )}
     </div>
   );
 };
@@ -268,7 +277,7 @@ export const Sidebar: React.FC = () => {
           animate={{ width: isExpanded ? 240 : 64 }}
           transition={isReload ? { duration: 0 } : { type: 'spring', damping: 28, stiffness: 280 }}
         >
-          <SidebarContent />
+          <SidebarContent variant="rail" />
         </motion.aside>
 
         {/* ── Mobile: slide-in drawer ────────────────────────────────────── */}
@@ -295,7 +304,7 @@ export const Sidebar: React.FC = () => {
                 >
                   ✕
                 </Button>
-                <SidebarContent />
+                <SidebarContent variant="drawer" />
               </motion.aside>
             )}
           </AnimatePresence>,


### PR DESCRIPTION
SidebarContent is shared by the desktop rail and the slide-in drawer. When the rail was collapsed (localStorage), the drawer inherited icon-only layout and showed the collapse control.

Add variant rail|drawer: drawer always expands labels/headings and omits the collapse footer; rail behavior is unchanged.

<img width="800" height="849" alt="Screenshot 2026-05-14 at 1 23 25 PM" src="https://github.com/user-attachments/assets/56b538ab-3499-487f-86d1-8f64080a0f73" />
