### PR TITLE
feat: implement personal access tokens management with creation, list…

### DIFF
--- a/backend/src/controllers/tokens.controller.ts
+++ b/backend/src/controllers/tokens.controller.ts
@@ -1,0 +1,32 @@
+import type { FastifyReply, FastifyRequest } from "fastify";
+import { ObjectId } from "mongodb";
+import { patService } from "../services/pat.service.js";
+
+function actorFromUser(user: { id: string; name: string; image?: string | null }) {
+  return { id: user.id, name: user.name, avatar: user.image ?? undefined };
+}
+
+export const tokensController = {
+  async list(req: FastifyRequest, _reply: FastifyReply) {
+    const tokens = await patService.listTokens(req.user!.id);
+    return { tokens };
+  },
+
+  async create(req: FastifyRequest<{ Body: { name: string } }>, reply: FastifyReply) {
+    const name = req.body.name.trim();
+    const { rawToken } = await patService.createToken(req.user!.id, name, actorFromUser(req.user!));
+    return reply.status(201).send({ token: rawToken, name });
+  },
+
+  async revoke(req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) {
+    const { id } = req.params;
+    if (!ObjectId.isValid(id)) {
+      return reply.status(404).send({ error: "Token not found" });
+    }
+    const deleted = await patService.revokeToken(req.user!.id, id, actorFromUser(req.user!));
+    if (!deleted) {
+      return reply.status(404).send({ error: "Token not found" });
+    }
+    return { success: true };
+  },
+};

--- a/backend/src/lib/ensure-indexes.ts
+++ b/backend/src/lib/ensure-indexes.ts
@@ -42,5 +42,10 @@ export async function ensureIndexes() {
   // 5. Timers for a user on a given UTC date
   await timers.createIndex({ userId: 1, date: 1 });
 
+  // Personal access tokens
+  const pats = db.collection("personal_access_tokens");
+  await pats.createIndex({ tokenHash: 1 }, { unique: true });
+  await pats.createIndex({ userId: 1 });
+
   console.log("MongoDB indexes ensured");
 }

--- a/backend/src/middleware/require-auth.ts
+++ b/backend/src/middleware/require-auth.ts
@@ -1,6 +1,9 @@
 import { FastifyReply, FastifyRequest } from "fastify";
 import { auth } from "../lib/auth.js";
 import { fromNodeHeaders } from "better-auth/node";
+import { ObjectId } from "mongodb";
+import { patService } from "../services/pat.service.js";
+import { usersCollection } from "../models/index.js";
 
 export type AppUser = {
   id: string;
@@ -9,7 +12,26 @@ export type AppUser = {
   image?: string | null;
 };
 
+const PAT_PREFIX = "th_pat_";
+
 export async function requireAuth(req: FastifyRequest, reply: FastifyReply) {
+  // Check for PAT Bearer token first (prefix: th_pat_)
+  const authHeader = req.headers["authorization"];
+  if (authHeader?.startsWith("Bearer " + PAT_PREFIX)) {
+    const rawToken = authHeader.slice("Bearer ".length);
+    const userId = await patService.validateToken(rawToken);
+    if (!userId) {
+      return reply.status(401).send({ error: "Invalid or expired token" });
+    }
+    const user = await usersCollection().findOne({ _id: new ObjectId(userId) });
+    if (!user) {
+      return reply.status(401).send({ error: "Unauthorized" });
+    }
+    req.user = { id: user._id.toString(), name: user.name, email: user.email, image: user.image };
+    return;
+  }
+
+  // Fall back to Better Auth session (cookie or session Bearer token)
   const session = await auth.api.getSession({
     headers: fromNodeHeaders(req.headers),
   });

--- a/backend/src/middleware/require-auth.ts
+++ b/backend/src/middleware/require-auth.ts
@@ -16,9 +16,11 @@ const PAT_PREFIX = "th_pat_";
 
 export async function requireAuth(req: FastifyRequest, reply: FastifyReply) {
   // Check for PAT Bearer token first (prefix: th_pat_)
+  // RFC 7235: auth scheme is case-insensitive, so normalise before matching.
   const authHeader = req.headers["authorization"];
-  if (authHeader?.startsWith("Bearer " + PAT_PREFIX)) {
-    const rawToken = authHeader.slice("Bearer ".length);
+  const lowerHeader = authHeader?.toLowerCase() ?? "";
+  if (lowerHeader.startsWith("bearer " + PAT_PREFIX)) {
+    const rawToken = authHeader!.slice("bearer ".length);
     const userId = await patService.validateToken(rawToken);
     if (!userId) {
       return reply.status(401).send({ error: "Invalid or expired token" });

--- a/backend/src/models/activity.model.ts
+++ b/backend/src/models/activity.model.ts
@@ -19,6 +19,15 @@ export interface TicketCreatedPayload {
   teamId: string;
 }
 
+export interface PATCreatedPayload {
+  tokenId: string;
+  name: string;
+}
+
+export interface PATRevokedPayload {
+  tokenId: string;
+}
+
 export interface TicketUpdatedPayload {
   ticketId: string;
   ticketTitle: string;
@@ -45,6 +54,8 @@ export const ActivityType = {
   ClockOut: "clock.out",
   TicketCreated: "ticket.created",
   TicketUpdated: "ticket.updated",
+  PATCreated: "pat.created",
+  PATRevoked: "pat.revoked",
 } as const;
 
 // ─── Discriminated union ──────────────────────────────────────────────────────
@@ -78,12 +89,24 @@ export interface TicketUpdatedActivity extends ActivityBase {
   payload: TicketUpdatedPayload;
 }
 
+export interface PATCreatedActivity extends ActivityBase {
+  type: "pat.created";
+  payload: PATCreatedPayload;
+}
+
+export interface PATRevokedActivity extends ActivityBase {
+  type: "pat.revoked";
+  payload: PATRevokedPayload;
+}
+
 /** Extensible discriminated union — add new variants here as features grow. */
 export type ActivityEvent =
   | ClockInActivity
   | ClockOutActivity
   | TicketCreatedActivity
-  | TicketUpdatedActivity;
+  | TicketUpdatedActivity
+  | PATCreatedActivity
+  | PATRevokedActivity;
 
 // ─── Emit input type ──────────────────────────────────────────────────────────
 
@@ -93,7 +116,9 @@ export type EmitActivityInput =
   | (Omit<ClockInActivity, "_id" | "occurredAt" | "source"> & WithDefaults)
   | (Omit<ClockOutActivity, "_id" | "occurredAt" | "source"> & WithDefaults)
   | (Omit<TicketCreatedActivity, "_id" | "occurredAt" | "source"> & WithDefaults)
-  | (Omit<TicketUpdatedActivity, "_id" | "occurredAt" | "source"> & WithDefaults);
+  | (Omit<TicketUpdatedActivity, "_id" | "occurredAt" | "source"> & WithDefaults)
+  | (Omit<PATCreatedActivity, "_id" | "occurredAt" | "source"> & WithDefaults)
+  | (Omit<PATRevokedActivity, "_id" | "occurredAt" | "source"> & WithDefaults);
 
 // ─── Public (API-facing) shape ────────────────────────────────────────────────
 

--- a/backend/src/models/index.ts
+++ b/backend/src/models/index.ts
@@ -16,6 +16,7 @@ import type { Timer } from "./timer.model.js";
 import type { ActivityEvent } from "./activity.model.js";
 import type { Channel } from "./channel.model.js";
 import type { ChannelMessage } from "./channel-message.model.js";
+import type { PersonalAccessToken } from "./personal-access-token.model.js";
 
 // Collection accessor — better-auth's MongoDB adapter uses "user" (singular)
 export function usersCollection() {
@@ -100,4 +101,9 @@ export function channelsCollection() {
 // Channel messages
 export function channelMessagesCollection() {
   return getDB().collection<ChannelMessage>("channelmessages");
+}
+
+// Personal access tokens
+export function personalAccessTokensCollection() {
+  return getDB().collection<PersonalAccessToken>("personal_access_tokens");
 }

--- a/backend/src/models/personal-access-token.model.ts
+++ b/backend/src/models/personal-access-token.model.ts
@@ -1,0 +1,10 @@
+import { ObjectId } from "mongodb";
+
+export interface PersonalAccessToken {
+  _id: ObjectId;
+  userId: string;
+  tokenHash: string; // SHA-256 of raw token — never stored in plaintext
+  name: string;
+  lastUsedAt?: Date;
+  createdAt: Date;
+}

--- a/backend/src/routes/tokens.ts
+++ b/backend/src/routes/tokens.ts
@@ -1,0 +1,108 @@
+import { FastifyInstance } from "fastify";
+import { requireAuth } from "../middleware/require-auth.js";
+import { patService } from "../services/pat.service.js";
+
+export async function tokenRoutes(app: FastifyInstance) {
+  // GET /v1/me/tokens — list tokens (no hash)
+  app.get(
+    "/me/tokens",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        tags: ["Users"],
+        summary: "List personal access tokens",
+        security: [{ cookieAuth: [] }],
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              tokens: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    _id: { type: "string" },
+                    name: { type: "string" },
+                    createdAt: { type: "string", format: "date-time" },
+                    lastUsedAt: { type: "string", format: "date-time", nullable: true },
+                  },
+                },
+              },
+            },
+          },
+        },
+      },
+    },
+    async (req) => {
+      const tokens = await patService.listTokens(req.user!.id);
+      return { tokens };
+    }
+  );
+
+  // POST /v1/me/tokens — create token, return raw once
+  app.post<{ Body: { name: string } }>(
+    "/me/tokens",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        tags: ["Users"],
+        summary: "Create a personal access token",
+        security: [{ cookieAuth: [] }],
+        body: {
+          type: "object",
+          required: ["name"],
+          properties: { name: { type: "string", minLength: 1, maxLength: 100 } },
+        },
+        response: {
+          201: {
+            type: "object",
+            properties: {
+              token: { type: "string", description: "Raw token — shown only once" },
+              name: { type: "string" },
+            },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const { name } = req.body;
+      const { rawToken } = await patService.createToken(req.user!.id, name);
+      return reply.status(201).send({ token: rawToken, name });
+    }
+  );
+
+  // DELETE /v1/me/tokens/:id — revoke token
+  app.delete<{ Params: { id: string } }>(
+    "/me/tokens/:id",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        tags: ["Users"],
+        summary: "Revoke a personal access token",
+        security: [{ cookieAuth: [] }],
+        params: {
+          type: "object",
+          required: ["id"],
+          properties: { id: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: { success: { type: "boolean" } },
+          },
+          404: {
+            type: "object",
+            properties: { error: { type: "string" } },
+          },
+        },
+      },
+    },
+    async (req, reply) => {
+      const deleted = await patService.revokeToken(req.user!.id, req.params.id);
+      if (!deleted) {
+        return reply.status(404).send({ error: "Token not found" });
+      }
+      return { success: true };
+    }
+  );
+}

--- a/backend/src/routes/tokens.ts
+++ b/backend/src/routes/tokens.ts
@@ -1,9 +1,9 @@
 import { FastifyInstance } from "fastify";
 import { requireAuth } from "../middleware/require-auth.js";
-import { patService } from "../services/pat.service.js";
+import { tokensController } from "../controllers/tokens.controller.js";
 
 export async function tokenRoutes(app: FastifyInstance) {
-  // GET /v1/me/tokens — list tokens (no hash)
+  // GET /v1/me/tokens — list tokens (no hash, no userId)
   app.get(
     "/me/tokens",
     {
@@ -33,10 +33,7 @@ export async function tokenRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (req) => {
-      const tokens = await patService.listTokens(req.user!.id);
-      return { tokens };
-    }
+    tokensController.list
   );
 
   // POST /v1/me/tokens — create token, return raw once
@@ -64,11 +61,7 @@ export async function tokenRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (req, reply) => {
-      const { name } = req.body;
-      const { rawToken } = await patService.createToken(req.user!.id, name);
-      return reply.status(201).send({ token: rawToken, name });
-    }
+    tokensController.create
   );
 
   // DELETE /v1/me/tokens/:id — revoke token
@@ -97,12 +90,6 @@ export async function tokenRoutes(app: FastifyInstance) {
         },
       },
     },
-    async (req, reply) => {
-      const deleted = await patService.revokeToken(req.user!.id, req.params.id);
-      if (!deleted) {
-        return reply.status(404).send({ error: "Token not found" });
-      }
-      return { success: true };
-    }
+    tokensController.revoke
   );
 }

--- a/backend/src/server.ts
+++ b/backend/src/server.ts
@@ -23,6 +23,7 @@ import { workRoutes } from "./routes/work.js";
 import { pulseVaultRoutes, pulseVaultCompatRoutes } from "./routes/pulsevault.js";
 import { presenceRoutes } from "./routes/presence.js";
 import { channelRoutes } from "./routes/channels.js";
+import { tokenRoutes } from "./routes/tokens.js";
 
 export async function buildApp(opts: { logger?: boolean } = {}): Promise<FastifyInstance> {
   const app = Fastify({ logger: opts.logger ?? true });
@@ -440,6 +441,7 @@ export async function buildApp(opts: { logger?: boolean } = {}): Promise<Fastify
   await app.register(workRoutes, { prefix: "/v1" });
   await app.register(presenceRoutes, { prefix: "/v1" });
   await app.register(channelRoutes, { prefix: "/v1" });
+  await app.register(tokenRoutes, { prefix: "/v1" });
 
   // Compat: old Pulse Cam configs saved the bare server URL (http://host:4000) and call
   // POST /reserve, POST /upload, PATCH /upload/:id etc. at root level.

--- a/backend/src/services/pat.service.ts
+++ b/backend/src/services/pat.service.ts
@@ -1,0 +1,51 @@
+import { createHash, randomBytes } from "crypto";
+import { ObjectId } from "mongodb";
+import { personalAccessTokensCollection } from "../models/index.js";
+
+const TOKEN_PREFIX = "th_pat_";
+
+function hashToken(raw: string): string {
+  return createHash("sha256").update(raw).digest("hex");
+}
+
+export const patService = {
+  async createToken(userId: string, name: string) {
+    const rawToken = TOKEN_PREFIX + randomBytes(32).toString("hex");
+    const tokenHash = hashToken(rawToken);
+
+    await personalAccessTokensCollection().insertOne({
+      _id: new ObjectId(),
+      userId,
+      tokenHash,
+      name,
+      createdAt: new Date(),
+    });
+
+    return { rawToken };
+  },
+
+  async listTokens(userId: string) {
+    return personalAccessTokensCollection()
+      .find({ userId }, { projection: { tokenHash: 0 } })
+      .sort({ createdAt: -1 })
+      .toArray();
+  },
+
+  async revokeToken(userId: string, tokenId: string) {
+    const result = await personalAccessTokensCollection().deleteOne({
+      _id: new ObjectId(tokenId),
+      userId,
+    });
+    return result.deletedCount === 1;
+  },
+
+  async validateToken(rawToken: string): Promise<string | null> {
+    const tokenHash = hashToken(rawToken);
+    const pat = await personalAccessTokensCollection().findOneAndUpdate(
+      { tokenHash },
+      { $set: { lastUsedAt: new Date() } },
+      { returnDocument: "after" }
+    );
+    return pat?.userId ?? null;
+  },
+};

--- a/backend/src/services/pat.service.ts
+++ b/backend/src/services/pat.service.ts
@@ -1,6 +1,7 @@
 import { createHash, randomBytes } from "crypto";
 import { ObjectId } from "mongodb";
 import { personalAccessTokensCollection } from "../models/index.js";
+import { emitActivity } from "./activity.service.js";
 
 const TOKEN_PREFIX = "th_pat_";
 
@@ -9,16 +10,28 @@ function hashToken(raw: string): string {
 }
 
 export const patService = {
-  async createToken(userId: string, name: string) {
+  async createToken(
+    userId: string,
+    name: string,
+    actor: { id: string; name: string; avatar?: string }
+  ) {
     const rawToken = TOKEN_PREFIX + randomBytes(32).toString("hex");
     const tokenHash = hashToken(rawToken);
+    const tokenId = new ObjectId();
 
     await personalAccessTokensCollection().insertOne({
-      _id: new ObjectId(),
+      _id: tokenId,
       userId,
       tokenHash,
       name,
       createdAt: new Date(),
+    });
+
+    void emitActivity({
+      userId,
+      actor,
+      type: "pat.created",
+      payload: { tokenId: tokenId.toHexString(), name },
     });
 
     return { rawToken };
@@ -26,17 +39,33 @@ export const patService = {
 
   async listTokens(userId: string) {
     return personalAccessTokensCollection()
-      .find({ userId }, { projection: { tokenHash: 0 } })
+      .find({ userId }, { projection: { tokenHash: 0, userId: 0 } })
       .sort({ createdAt: -1 })
       .toArray();
   },
 
-  async revokeToken(userId: string, tokenId: string) {
+  async revokeToken(
+    userId: string,
+    tokenId: string,
+    actor: { id: string; name: string; avatar?: string }
+  ) {
+    if (!ObjectId.isValid(tokenId)) return false;
+
     const result = await personalAccessTokensCollection().deleteOne({
       _id: new ObjectId(tokenId),
       userId,
     });
-    return result.deletedCount === 1;
+
+    if (result.deletedCount === 1) {
+      void emitActivity({
+        userId,
+        actor,
+        type: "pat.revoked",
+        payload: { tokenId },
+      });
+      return true;
+    }
+    return false;
   },
 
   async validateToken(rawToken: string): Promise<string | null> {

--- a/backend/tests/tokens.test.ts
+++ b/backend/tests/tokens.test.ts
@@ -159,7 +159,6 @@ describe("POST /v1/me/tokens", () => {
 
 describe("PAT Bearer auth via requireAuth middleware", () => {
   let rawToken: string;
-  let tokenId: string;
 
   beforeAll(async () => {
     const res = await app.inject({
@@ -176,7 +175,8 @@ describe("PAT Bearer auth via requireAuth middleware", () => {
       headers: { cookie: aliceCookie },
     });
     const tokens = listRes.json().tokens as Array<{ _id: string; name: string }>;
-    tokenId = tokens.find((t) => t.name === "Bearer Test Token")!._id;
+    // Verify the token appears in the list (no-op assignment avoided)
+    expect(tokens.some((t) => t.name === "Bearer Test Token")).toBe(true);
   });
 
   afterAll(async () => {

--- a/backend/tests/tokens.test.ts
+++ b/backend/tests/tokens.test.ts
@@ -1,0 +1,293 @@
+/**
+ * Personal Access Token routes — integration tests.
+ *
+ * Covers:
+ *   GET    /v1/me/tokens         — list tokens
+ *   POST   /v1/me/tokens         — create token (returns raw once)
+ *   DELETE /v1/me/tokens/:id     — revoke token
+ *   requireAuth middleware        — Bearer PAT auth branch
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { FastifyInstance } from "fastify";
+import { buildApp } from "../src/server.js";
+import { connectDB, client } from "../src/lib/db.js";
+import { auth } from "../src/lib/auth.js";
+
+// ─── Fixtures ─────────────────────────────────────────────────────────────────
+
+const ALICE = { name: "Tokens Alice", email: "tokens-alice@test.dev", password: "Password1!" };
+const BOB = { name: "Tokens Bob", email: "tokens-bob@test.dev", password: "Password1!" };
+
+let app: FastifyInstance;
+let aliceCookie: string;
+let bobCookie: string;
+let aliceId: string;
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function getSessionCookie(email: string, password: string): Promise<string> {
+  const res = (await auth.api.signInEmail({
+    body: { email, password },
+    asResponse: true,
+  })) as Response;
+  const rawCookies = res.headers.getSetCookie?.() ?? [res.headers.get("set-cookie") ?? ""];
+  return rawCookies.map((c) => c.split(";")[0].trim()).join("; ");
+}
+
+async function purgeUser(email: string) {
+  const db = client.db();
+  const user = await db.collection("user").findOne({ email });
+  if (!user) return;
+  const userId = String(user._id);
+  await Promise.all([
+    db.collection("account").deleteMany({ userId }),
+    db.collection("session").deleteMany({ userId }),
+    db.collection("personal_access_tokens").deleteMany({ userId }),
+    db.collection("user").deleteOne({ _id: user._id }),
+  ]);
+}
+
+// ─── Setup / Teardown ─────────────────────────────────────────────────────────
+
+beforeAll(async () => {
+  await connectDB();
+  app = await buildApp({ logger: false });
+  await app.ready();
+
+  await Promise.all([purgeUser(ALICE.email), purgeUser(BOB.email)]);
+
+  await auth.api.signUpEmail({ body: ALICE });
+  await auth.api.signUpEmail({ body: BOB });
+
+  aliceId = String((await client.db().collection("user").findOne({ email: ALICE.email }))!._id);
+
+  aliceCookie = await getSessionCookie(ALICE.email, ALICE.password);
+  bobCookie = await getSessionCookie(BOB.email, BOB.password);
+}, 20000);
+
+afterAll(async () => {
+  await Promise.all([purgeUser(ALICE.email), purgeUser(BOB.email)]);
+  await app.close();
+});
+
+// ─── GET /v1/me/tokens ────────────────────────────────────────────────────────
+
+describe("GET /v1/me/tokens", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "GET", url: "/v1/me/tokens" });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns an empty list initially", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json();
+    expect(body.tokens).toBeInstanceOf(Array);
+    expect(body.tokens).toHaveLength(0);
+  });
+});
+
+// ─── POST /v1/me/tokens ───────────────────────────────────────────────────────
+
+describe("POST /v1/me/tokens", () => {
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      payload: { name: "CI Token" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 400 when name is empty", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+      payload: { name: "" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
+  it("creates a token and returns raw value once — 201", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+      payload: { name: "My CI Token" },
+    });
+    expect(res.statusCode).toBe(201);
+    const body = res.json();
+    expect(body.token).toMatch(/^th_pat_/);
+    expect(body.name).toBe("My CI Token");
+  });
+
+  it("stores only the hash — raw token not in DB", async () => {
+    const createRes = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+      payload: { name: "Hash Check Token" },
+    });
+    const { token } = createRes.json() as { token: string };
+
+    const stored = await client
+      .db()
+      .collection("personal_access_tokens")
+      .findOne({ userId: aliceId });
+
+    expect(stored).not.toBeNull();
+    // tokenHash should not equal raw token value
+    expect(stored!.tokenHash).not.toBe(token);
+    // tokenHash should look like a sha256 hex (64 chars)
+    expect(stored!.tokenHash).toMatch(/^[0-9a-f]{64}$/);
+
+    // Cleanup
+    await client
+      .db()
+      .collection("personal_access_tokens")
+      .deleteMany({ userId: aliceId, name: "Hash Check Token" });
+  });
+});
+
+// ─── Auth via Bearer PAT ──────────────────────────────────────────────────────
+
+describe("PAT Bearer auth via requireAuth middleware", () => {
+  let rawToken: string;
+  let tokenId: string;
+
+  beforeAll(async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+      payload: { name: "Bearer Test Token" },
+    });
+    rawToken = res.json().token;
+
+    const listRes = await app.inject({
+      method: "GET",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+    });
+    const tokens = listRes.json().tokens as Array<{ _id: string; name: string }>;
+    tokenId = tokens.find((t) => t.name === "Bearer Test Token")!._id;
+  });
+
+  afterAll(async () => {
+    // Ensure cleanup even if revoke test is skipped
+    await client
+      .db()
+      .collection("personal_access_tokens")
+      .deleteMany({ userId: aliceId, name: "Bearer Test Token" });
+  });
+
+  it("authenticates via Bearer token — can GET /v1/me", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: { authorization: `Bearer ${rawToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().user.email).toBe(ALICE.email);
+  });
+
+  it("accepts bearer (lowercase scheme) per RFC 7235", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: { authorization: `bearer ${rawToken}` },
+    });
+    expect(res.statusCode).toBe(200);
+  });
+
+  it("returns 401 for invalid token", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: { authorization: "Bearer th_pat_invalid000000000000" },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+});
+
+// ─── DELETE /v1/me/tokens/:id ─────────────────────────────────────────────────
+
+describe("DELETE /v1/me/tokens/:id", () => {
+  let tokenId: string;
+  let rawToken: string;
+
+  beforeAll(async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+      payload: { name: "Revoke Test Token" },
+    });
+    rawToken = res.json().token;
+
+    const listRes = await app.inject({
+      method: "GET",
+      url: "/v1/me/tokens",
+      headers: { cookie: aliceCookie },
+    });
+    const tokens = listRes.json().tokens as Array<{ _id: string; name: string }>;
+    tokenId = tokens.find((t) => t.name === "Revoke Test Token")!._id;
+  });
+
+  it("returns 401 without auth", async () => {
+    const res = await app.inject({ method: "DELETE", url: `/v1/me/tokens/${tokenId}` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for invalid ObjectId", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: "/v1/me/tokens/not-an-id",
+      headers: { cookie: aliceCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("prevents cross-user revocation — returns 404", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/me/tokens/${tokenId}`,
+      headers: { cookie: bobCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  it("revokes own token — 200", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/me/tokens/${tokenId}`,
+      headers: { cookie: aliceCookie },
+    });
+    expect(res.statusCode).toBe(200);
+    expect(res.json().success).toBe(true);
+  });
+
+  it("revoked token returns 401 for Bearer auth", async () => {
+    const res = await app.inject({
+      method: "GET",
+      url: "/v1/me",
+      headers: { authorization: `Bearer ${rawToken}` },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it("returns 404 for already-revoked token", async () => {
+    const res = await app.inject({
+      method: "DELETE",
+      url: `/v1/me/tokens/${tokenId}`,
+      headers: { cookie: aliceCookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+});

--- a/e2e/api-token.spec.ts
+++ b/e2e/api-token.spec.ts
@@ -1,0 +1,219 @@
+/**
+ * API Token Integration E2E
+ *
+ * Guards the full lifecycle of a personal access token (PAT):
+ *   1. Navigate to Settings → API Tokens section
+ *   2. Generate a token — verify the one-time reveal appears
+ *   3. Copy the token value from the DOM
+ *   4. Token is listed in the token list
+ *   5. Use the token as Bearer auth against the backend API
+ *   6. Revoke the token — it disappears from the list
+ *   7. Verify the token is rejected (401) after revocation
+ *
+ * If this test breaks, integrations that rely on PAT authentication are broken.
+ */
+import { expect, test } from '@playwright/test';
+
+const TEST_EMAIL = 'alice@example.com';
+const TEST_PASSWORD = 'Password1!';
+const API_BASE = 'http://localhost:4000/v1';
+const PAT_PREFIX = 'th_pat_';
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+async function login(page: import('@playwright/test').Page) {
+  await page.goto('/app');
+  await page.waitForSelector('input[type="email"]', { timeout: 10000 });
+  await page.fill('input[type="email"]', TEST_EMAIL);
+  await page.fill('input[type="password"]', TEST_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard', { timeout: 15000 });
+}
+
+async function goToSettings(page: import('@playwright/test').Page) {
+  await page.goto('/app/settings');
+  // Wait for the API Tokens section heading to appear
+  await page.waitForSelector('text=API Tokens', { timeout: 10000 });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('API Token — Settings page lifecycle', () => {
+  test.setTimeout(90000);
+
+  test('generates a PAT, verifies it works via API, then revokes it and confirms 401', async ({
+    page,
+    request,
+  }) => {
+    await login(page);
+    await goToSettings(page);
+
+    // Scroll the API Tokens section into view
+    const apiTokensSection = page.getByText('API Tokens').first();
+    await apiTokensSection.scrollIntoViewIfNeeded();
+
+    // ── Step 1: Generate a token ───────────────────────────────────────────────
+
+    const tokenName = `e2e-integration-${Date.now()}`;
+
+    const nameInput = page.getByPlaceholder('Token name (e.g. TimeHarbor)');
+    await expect(nameInput).toBeVisible({ timeout: 8000 });
+    await nameInput.fill(tokenName);
+
+    const generateBtn = page.getByRole('button', { name: 'Generate' });
+    await expect(generateBtn).toBeEnabled({ timeout: 5000 });
+    await generateBtn.click();
+
+    // ── Step 2: One-time reveal appears ───────────────────────────────────────
+
+    const warningText = page.getByText("Save this token now — it won't be shown again.");
+    await expect(warningText).toBeVisible({ timeout: 8000 });
+
+    // Read the raw token from the <code> element inside the reveal banner
+    const tokenCode = page
+      .locator('code')
+      .filter({ hasText: PAT_PREFIX })
+      .first();
+    await expect(tokenCode).toBeVisible({ timeout: 5000 });
+
+    const rawToken = await tokenCode.innerText();
+    expect(rawToken).toMatch(new RegExp(`^${PAT_PREFIX}`));
+
+    // ── Step 3: Copy button works ──────────────────────────────────────────────
+
+    await page.context().grantPermissions(['clipboard-read', 'clipboard-write']);
+
+    const copyBtn = page.getByRole('button', { name: 'Copy' });
+    await expect(copyBtn).toBeVisible();
+    await copyBtn.click();
+    await expect(page.getByRole('button', { name: 'Copied!' })).toBeVisible({ timeout: 5000 });
+
+    // ── Step 4: Token appears in the list ─────────────────────────────────────
+
+    await expect(page.getByText(tokenName)).toBeVisible({ timeout: 5000 });
+
+    // Confirm at least one Revoke button is present in the tokens section
+    await expect(page.getByRole('button', { name: 'Revoke' }).first()).toBeVisible({
+      timeout: 5000,
+    });
+
+    // ── Step 5: Token authenticates against the backend API ───────────────────
+
+    // GET /v1/me/tokens — must return 200 with our token in the list
+    const listResponse = await request.get(`${API_BASE}/me/tokens`, {
+      headers: { Authorization: `Bearer ${rawToken}` },
+    });
+    expect(listResponse.status()).toBe(200);
+    const listBody = await listResponse.json();
+    expect(listBody.tokens).toBeDefined();
+    const ourToken = (listBody.tokens as Array<{ _id: string; name: string }>).find(
+      (t) => t.name === tokenName,
+    );
+    expect(ourToken).toBeDefined();
+
+    // GET /v1/health — basic connectivity check
+    const healthResponse = await request.get(`${API_BASE.replace('/v1', '')}/health`);
+    expect(healthResponse.status()).toBe(200);
+
+    // ── Step 6: Revoke via API (tests DELETE endpoint) ────────────────────────
+
+    const revokeResponse = await request.delete(`${API_BASE}/me/tokens/${ourToken!._id}`, {
+      headers: { Authorization: `Bearer ${rawToken}` },
+    });
+    expect(revokeResponse.status()).toBe(200);
+    const revokeBody = await revokeResponse.json();
+    expect(revokeBody.success).toBe(true);
+
+    // Reload to confirm the UI removes the revoked token from the list
+    await page.reload();
+    await page.waitForSelector('text=API Tokens', { timeout: 10000 });
+    await expect(page.getByText(tokenName)).not.toBeVisible({ timeout: 8000 });
+
+    // ── Step 7: Revoked token is rejected by the API ──────────────────────────
+
+    const revokedResponse = await request.get(`${API_BASE}/me/tokens`, {
+      headers: { Authorization: `Bearer ${rawToken}` },
+    });
+    expect(revokedResponse.status()).toBe(401);
+  });
+
+  test('cannot generate a token without a name', async ({ page }) => {
+    await login(page);
+    await goToSettings(page);
+
+    const apiTokensSection = page.getByText('API Tokens').first();
+    await apiTokensSection.scrollIntoViewIfNeeded();
+
+    const generateBtn = page.getByRole('button', { name: 'Generate' });
+    await expect(generateBtn).toBeVisible({ timeout: 8000 });
+
+    // Button must be disabled when the name input is empty
+    await expect(generateBtn).toBeDisabled();
+  });
+
+  test('multiple tokens can be generated and are listed independently', async ({
+    page,
+    request,
+  }) => {
+    await login(page);
+    await goToSettings(page);
+
+    const apiTokensSection = page.getByText('API Tokens').first();
+    await apiTokensSection.scrollIntoViewIfNeeded();
+
+    const ts = Date.now();
+    const nameA = `e2e-multi-A-${ts}`;
+    const nameB = `e2e-multi-B-${ts}`;
+
+    // Create token A
+    const nameInput = page.getByPlaceholder('Token name (e.g. TimeHarbor)');
+    await nameInput.fill(nameA);
+    await page.getByRole('button', { name: 'Generate' }).click();
+
+    const tokenCodeA = page.locator('code').filter({ hasText: PAT_PREFIX }).first();
+    await expect(tokenCodeA).toBeVisible({ timeout: 8000 });
+    const rawTokenA = await tokenCodeA.innerText();
+
+    // Create token B
+    await nameInput.fill(nameB);
+    await page.getByRole('button', { name: 'Generate' }).click();
+
+    const tokenCodeB = page.locator('code').filter({ hasText: PAT_PREFIX }).first();
+    await expect(tokenCodeB).toBeVisible({ timeout: 8000 });
+    const rawTokenB = await tokenCodeB.innerText();
+
+    // Both tokens must appear in the list
+    await expect(page.getByText(nameA)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(nameB)).toBeVisible({ timeout: 5000 });
+
+    // Both tokens must independently authenticate
+    const respA = await request.get(`${API_BASE}/me/tokens`, {
+      headers: { Authorization: `Bearer ${rawTokenA}` },
+    });
+    expect(respA.status()).toBe(200);
+
+    const respB = await request.get(`${API_BASE}/me/tokens`, {
+      headers: { Authorization: `Bearer ${rawTokenB}` },
+    });
+    expect(respB.status()).toBe(200);
+
+    // Cleanup — revoke both using API directly to avoid locator ambiguity
+    const tokensResp = await request.get(`${API_BASE}/me/tokens`, {
+      headers: { Authorization: `Bearer ${rawTokenA}` },
+    });
+    const tokensBody = await tokensResp.json();
+    const allTokens = tokensBody.tokens as Array<{ _id: string; name: string }>;
+
+    for (const t of allTokens.filter((t) => t.name === nameA || t.name === nameB)) {
+      await request.delete(`${API_BASE}/me/tokens/${t._id}`, {
+        headers: { Authorization: `Bearer ${rawTokenA}` },
+      });
+    }
+
+    // Reload to confirm they're gone from the UI
+    await page.reload();
+    await page.waitForSelector('text=API Tokens', { timeout: 10000 });
+    await expect(page.getByText(nameA)).not.toBeVisible({ timeout: 8000 });
+    await expect(page.getByText(nameB)).not.toBeVisible({ timeout: 8000 });
+  });
+});

--- a/e2e/api-token.spec.ts
+++ b/e2e/api-token.spec.ts
@@ -70,10 +70,7 @@ test.describe('API Token — Settings page lifecycle', () => {
     await expect(warningText).toBeVisible({ timeout: 8000 });
 
     // Read the raw token from the <code> element inside the reveal banner
-    const tokenCode = page
-      .locator('code')
-      .filter({ hasText: PAT_PREFIX })
-      .first();
+    const tokenCode = page.locator('code').filter({ hasText: PAT_PREFIX }).first();
     await expect(tokenCode).toBeVisible({ timeout: 5000 });
 
     const rawToken = await tokenCode.innerText();

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -972,7 +972,6 @@ export const channelApi = {
     }),
 };
 
-
 // ─── Personal Access Tokens ───────────────────────────────────────────────────
 
 export interface PersonalAccessToken {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -971,3 +971,30 @@ export const channelApi = {
       return url.toString();
     }),
 };
+
+
+// ─── Personal Access Tokens ───────────────────────────────────────────────────
+
+export interface PersonalAccessToken {
+  _id: string;
+  name: string;
+  createdAt: string;
+  lastUsedAt?: string | null;
+}
+
+export const tokenApi = {
+  list: (): Promise<PersonalAccessToken[]> =>
+    request<{ tokens: PersonalAccessToken[] }>('/v1/me/tokens').then((r) => r.tokens),
+
+  create: (name: string): Promise<{ token: string; name: string }> =>
+    request<{ token: string; name: string }>('/v1/me/tokens', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ name }),
+    }),
+
+  revoke: (id: string): Promise<void> =>
+    request<{ success: boolean }>(`/v1/me/tokens/${encodeURIComponent(id)}`, {
+      method: 'DELETE',
+    }).then(() => undefined),
+};

--- a/src/ui/SettingsPage.tsx
+++ b/src/ui/SettingsPage.tsx
@@ -39,7 +39,14 @@ import {
   subscribeToPush,
   unsubscribeFromPush,
 } from '../lib/nativePush';
-import { authApi, userApi, notificationApi, teamApi, tokenApi, type PersonalAccessToken } from '../lib/api';
+import {
+  authApi,
+  userApi,
+  notificationApi,
+  teamApi,
+  tokenApi,
+  type PersonalAccessToken,
+} from '../lib/api';
 import { GitHubConnectionRow } from './GitHubConnectionRow';
 import { PROFILE_BIO_MAX, PROFILE_DISPLAY_NAME_MAX, PROFILE_WEBSITE_MAX } from '../lib/constants';
 import { useBrand, BRANDS } from '../lib/useBrand';
@@ -525,7 +532,9 @@ const ApiTokensManager: React.FC = () => {
     }
   }, []);
 
-  useEffect(() => { void load(); }, [load]);
+  useEffect(() => {
+    void load();
+  }, [load]);
 
   const handleCreate = async () => {
     const name = newTokenName.trim();
@@ -565,13 +574,17 @@ const ApiTokensManager: React.FC = () => {
     <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
       {/* Create new token */}
       <div className="flex flex-col gap-3 px-5 py-4">
-        <Text size="xs" weight="medium">Generate new token</Text>
+        <Text size="xs" weight="medium">
+          Generate new token
+        </Text>
         <div className="flex gap-2">
           <Input
             placeholder="Token name (e.g. TimeHarbor)"
             value={newTokenName}
             onChange={(e) => setNewTokenName(e.target.value)}
-            onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter') void handleCreate();
+            }}
             className="flex-1"
           />
           <Button
@@ -584,7 +597,11 @@ const ApiTokensManager: React.FC = () => {
             Generate
           </Button>
         </div>
-        {error && <Text size="xs" className="text-red-500">{error}</Text>}
+        {error && (
+          <Text size="xs" className="text-red-500">
+            {error}
+          </Text>
+        )}
       </div>
 
       {/* One-time token reveal */}
@@ -607,27 +624,31 @@ const ApiTokensManager: React.FC = () => {
       {/* Token list */}
       {loading ? (
         <div className="px-5 py-3">
-          <Text variant="muted" size="xs">Loading…</Text>
+          <Text variant="muted" size="xs">
+            Loading…
+          </Text>
         </div>
       ) : tokens.length === 0 ? (
         <div className="px-5 py-3">
-          <Text variant="muted" size="xs">No tokens yet.</Text>
+          <Text variant="muted" size="xs">
+            No tokens yet.
+          </Text>
         </div>
       ) : (
         tokens.map((t) => (
           <div key={t._id} className="flex items-center justify-between px-5 py-3">
             <div className="flex flex-col gap-0.5">
-              <Text size="xs" weight="medium">{t.name}</Text>
+              <Text size="xs" weight="medium">
+                {t.name}
+              </Text>
               <Text variant="muted" size="xs">
                 Created {new Date(t.createdAt).toLocaleDateString()}
-                {t.lastUsedAt ? ` · Last used ${new Date(t.lastUsedAt).toLocaleDateString()}` : ' · Never used'}
+                {t.lastUsedAt
+                  ? ` · Last used ${new Date(t.lastUsedAt).toLocaleDateString()}`
+                  : ' · Never used'}
               </Text>
             </div>
-            <Button
-              size="sm"
-              variant="danger"
-              onClick={() => void handleRevoke(t._id)}
-            >
+            <Button size="sm" variant="danger" onClick={() => void handleRevoke(t._id)}>
               Revoke
             </Button>
           </div>

--- a/src/ui/SettingsPage.tsx
+++ b/src/ui/SettingsPage.tsx
@@ -525,8 +525,8 @@ const ApiTokensManager: React.FC = () => {
     try {
       const list = await tokenApi.list();
       setTokens(list);
-    } catch {
-      // silently ignore — tokens section just shows empty
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to load tokens');
     } finally {
       setLoading(false);
     }
@@ -565,9 +565,13 @@ const ApiTokensManager: React.FC = () => {
 
   const handleCopy = async () => {
     if (!createdToken) return;
-    await navigator.clipboard.writeText(createdToken);
-    setCopied(true);
-    setTimeout(() => setCopied(false), 2000);
+    try {
+      await navigator.clipboard.writeText(createdToken);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      setError('Failed to copy — please copy the token manually.');
+    }
   };
 
   return (

--- a/src/ui/SettingsPage.tsx
+++ b/src/ui/SettingsPage.tsx
@@ -10,6 +10,7 @@ import {
   faBell,
   faGear,
   faInfo,
+  faKey,
   faPalette,
   faRotateLeft,
   faRightFromBracket,
@@ -38,7 +39,7 @@ import {
   subscribeToPush,
   unsubscribeFromPush,
 } from '../lib/nativePush';
-import { authApi, userApi, notificationApi, teamApi } from '../lib/api';
+import { authApi, userApi, notificationApi, teamApi, tokenApi, type PersonalAccessToken } from '../lib/api';
 import { GitHubConnectionRow } from './GitHubConnectionRow';
 import { PROFILE_BIO_MAX, PROFILE_DISPLAY_NAME_MAX, PROFILE_WEBSITE_MAX } from '../lib/constants';
 import { useBrand, BRANDS } from '../lib/useBrand';
@@ -502,6 +503,140 @@ const ProfileEditor: React.FC = () => {
 
 // ─── SettingsPage ─────────────────────────────────────────────────────────────
 
+// ─── API Tokens Manager ───────────────────────────────────────────────────────
+
+const ApiTokensManager: React.FC = () => {
+  const [tokens, setTokens] = useState<PersonalAccessToken[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [newTokenName, setNewTokenName] = useState('');
+  const [createdToken, setCreatedToken] = useState<string | null>(null);
+  const [creating, setCreating] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [copied, setCopied] = useState(false);
+
+  const load = useCallback(async () => {
+    try {
+      const list = await tokenApi.list();
+      setTokens(list);
+    } catch {
+      // silently ignore — tokens section just shows empty
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => { void load(); }, [load]);
+
+  const handleCreate = async () => {
+    const name = newTokenName.trim();
+    if (!name) return;
+    setCreating(true);
+    setError(null);
+    setCreatedToken(null);
+    try {
+      const result = await tokenApi.create(name);
+      setCreatedToken(result.token);
+      setNewTokenName('');
+      await load();
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to create token');
+    } finally {
+      setCreating(false);
+    }
+  };
+
+  const handleRevoke = async (id: string) => {
+    try {
+      await tokenApi.revoke(id);
+      setTokens((prev) => prev.filter((t) => t._id !== id));
+    } catch (err: unknown) {
+      setError(err instanceof Error ? err.message : 'Failed to revoke token');
+    }
+  };
+
+  const handleCopy = async () => {
+    if (!createdToken) return;
+    await navigator.clipboard.writeText(createdToken);
+    setCopied(true);
+    setTimeout(() => setCopied(false), 2000);
+  };
+
+  return (
+    <div className="divide-y divide-neutral-100 dark:divide-neutral-800">
+      {/* Create new token */}
+      <div className="flex flex-col gap-3 px-5 py-4">
+        <Text size="xs" weight="medium">Generate new token</Text>
+        <div className="flex gap-2">
+          <Input
+            placeholder="Token name (e.g. TimeHarbor)"
+            value={newTokenName}
+            onChange={(e) => setNewTokenName(e.target.value)}
+            onKeyDown={(e) => { if (e.key === 'Enter') void handleCreate(); }}
+            className="flex-1"
+          />
+          <Button
+            size="sm"
+            onClick={() => void handleCreate()}
+            disabled={!newTokenName.trim() || creating}
+            isLoading={creating}
+            loadingText="Creating…"
+          >
+            Generate
+          </Button>
+        </div>
+        {error && <Text size="xs" className="text-red-500">{error}</Text>}
+      </div>
+
+      {/* One-time token reveal */}
+      {createdToken && (
+        <div className="flex flex-col gap-2 bg-amber-50 px-5 py-4 dark:bg-amber-950/30">
+          <Text size="xs" weight="medium" className="text-amber-700 dark:text-amber-400">
+            Save this token now — it won't be shown again.
+          </Text>
+          <div className="flex items-center gap-2">
+            <code className="flex-1 break-all rounded bg-neutral-100 px-2 py-1 font-mono text-xs dark:bg-neutral-800">
+              {createdToken}
+            </code>
+            <Button size="sm" variant="outline" onClick={() => void handleCopy()}>
+              {copied ? 'Copied!' : 'Copy'}
+            </Button>
+          </div>
+        </div>
+      )}
+
+      {/* Token list */}
+      {loading ? (
+        <div className="px-5 py-3">
+          <Text variant="muted" size="xs">Loading…</Text>
+        </div>
+      ) : tokens.length === 0 ? (
+        <div className="px-5 py-3">
+          <Text variant="muted" size="xs">No tokens yet.</Text>
+        </div>
+      ) : (
+        tokens.map((t) => (
+          <div key={t._id} className="flex items-center justify-between px-5 py-3">
+            <div className="flex flex-col gap-0.5">
+              <Text size="xs" weight="medium">{t.name}</Text>
+              <Text variant="muted" size="xs">
+                Created {new Date(t.createdAt).toLocaleDateString()}
+                {t.lastUsedAt ? ` · Last used ${new Date(t.lastUsedAt).toLocaleDateString()}` : ' · Never used'}
+              </Text>
+            </div>
+            <Button
+              size="sm"
+              variant="danger"
+              onClick={() => void handleRevoke(t._id)}
+            >
+              Revoke
+            </Button>
+          </div>
+        ))
+      )}
+    </div>
+  );
+};
+
 export const SettingsPage: React.FC = () => {
   const { user, signOut } = useSession();
   const [resetBusy, setResetBusy] = useState(false);
@@ -551,6 +686,15 @@ export const SettingsPage: React.FC = () => {
         description="Browser alerts for team clock in/out (same as Time Harbor)."
       >
         <PushNotificationsSettings />
+      </Section>
+
+      {/* API Tokens */}
+      <Section
+        icon={faKey}
+        title="API Tokens"
+        description="Generate tokens to connect external services like TimeHarbor."
+      >
+        <ApiTokensManager />
       </Section>
 
       {/* Account */}


### PR DESCRIPTION
This pull request introduces a full-featured Personal Access Token (PAT) system, allowing users to generate, list, and revoke API tokens for authenticating external services. The implementation covers backend database models, API endpoints, authentication logic, and a user-facing management interface in the settings page.

**Highlights of the changes:**

### Backend: Personal Access Token Infrastructure

* Added a new `personal_access_tokens` MongoDB collection, including a schema (`PersonalAccessToken`) and unique indexes for secure storage and lookup by hashed token and user ID. 
* Implemented the `patService` with methods to create, list, revoke, and validate tokens, storing only SHA-256 token hashes and updating usage timestamps.

### Backend: API & Authentication

* Added new REST API routes under `/v1/me/tokens` for managing tokens: listing, creating (with one-time raw token reveal), and revoking. [[1]](diffhunk://#diff-8b800bd76806ba1850ddf193481bbd974e54cdc935fb5bb37dba2612e390ed88R1-R108) [[2]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR26) [[3]](diffhunk://#diff-03830d1462a5acd300db5f366d82d5232c32ff001e382f55d3cca74a65be60aaR444)
* Updated the authentication middleware to support Bearer authentication using PATs (with `th_pat_` prefix), falling back to session/cookie auth if not present. 

### Frontend: API Integration & UI

* Added `tokenApi` to the client API layer for interacting with the new PAT endpoints, and defined the corresponding TypeScript types.
* Implemented an "API Tokens" section in the settings page, allowing users to generate, view, copy, and revoke tokens, with a one-time warning for new tokens. 

These changes together provide a secure, user-friendly mechanism for external integrations and automation via personal API tokens.…ing, and revocation