### PR TITLE
feat(ui): show clock-in timer in header and tab title (#164)

### DIFF
--- a/e2e/tickets.spec.ts
+++ b/e2e/tickets.spec.ts
@@ -81,33 +81,41 @@ test.describe('Tickets', () => {
   });
 
   test('create a ticket by pasting GitHub PR URL into title field', async ({ page }) => {
+    const issueUrl = 'https://github.com/microsoft/vscode/issues/1';
+    const mockTitle = 'E2E mock GitHub issue title';
+
+    // Avoid flaky CI failures from GitHub API rate limits / network
+    await page.route('**/repos/microsoft/vscode/issues/1', async (route) => {
+      await route.fulfill({
+        status: 200,
+        contentType: 'application/json',
+        body: JSON.stringify({ title: mockTitle }),
+      });
+    });
+
     await page.getByRole('button', { name: 'New Ticket' }).click();
 
     // Paste a well-known public GitHub issue URL into the title input
-    await pasteInto(page, 'Ticket title', 'https://github.com/microsoft/vscode/issues/1');
-
-    // Wait for the GitHub API fetch to resolve
-    await page.waitForTimeout(5000);
+    await pasteInto(page, 'Ticket title', issueUrl);
 
     const titleInput = page.getByPlaceholder('Ticket title');
     const urlInput = page.getByPlaceholder('GitHub / Redmine URL (optional)');
 
     // Title should be auto-populated (not the raw URL)
-    const titleValue = await titleInput.inputValue();
-    expect(titleValue.length).toBeGreaterThan(0);
-    expect(titleValue).not.toContain('github.com');
+    await expect(titleInput).toHaveValue(mockTitle, { timeout: 10000 });
+    await expect(titleInput).not.toHaveValue(/github\.com/);
 
     // URL field should hold the pasted URL
-    await expect(urlInput).toHaveValue('https://github.com/microsoft/vscode/issues/1');
+    await expect(urlInput).toHaveValue(issueUrl);
 
     // Create the ticket
     await page.getByRole('button', { name: 'Create Ticket' }).click();
     await page.waitForTimeout(1000);
 
-    await expect(page.getByText(titleValue).first()).toBeVisible();
+    await expect(page.getByText(mockTitle).first()).toBeVisible();
 
     // Cleanup
-    await deleteTicket(page, titleValue);
+    await deleteTicket(page, mockTitle);
   });
 
   // ── Edit ───────────────────────────────────────────────────────────────────

--- a/src/features/clock/ClockPage.tsx
+++ b/src/features/clock/ClockPage.tsx
@@ -7,7 +7,7 @@ import { Card, CardContent, CardHeader, CardTitle, Spinner, Text } from '@mieweb
 import React from 'react';
 
 import { useTeam } from '../../lib/TeamContext';
-import { formatTimer } from '../../lib/timeUtils';
+import { formatTimer, getActiveClockSeconds } from '../../lib/timeUtils';
 import { AppPage } from '../../ui/AppPage';
 import { useClockToggle } from '../../lib/useClockToggle';
 
@@ -19,9 +19,7 @@ export const ClockPage: React.FC = () => {
   const { clockIn, clockOut, clockInLoading, clockOutLoading } = useClockToggle();
 
   // Session duration
-  const sessionSeconds = activeClockEvent
-    ? Math.floor((currentTime - activeClockEvent.startTime) / 1000)
-    : 0;
+  const sessionSeconds = getActiveClockSeconds(activeClockEvent, currentTime);
 
   // Live wall-clock display
   const currentTimeDisplay = new Date(currentTime).toLocaleTimeString([], {

--- a/src/lib/timeUtils.test.ts
+++ b/src/lib/timeUtils.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest';
+
+import {
+  formatDuration,
+  formatTimer,
+  getActiveClockSeconds,
+  startOfDay,
+  endOfDay,
+  toDateString,
+} from './timeUtils';
+
+describe('formatDuration', () => {
+  it('formats hours and minutes', () => {
+    expect(formatDuration(3661)).toBe('1h 1m');
+    expect(formatDuration(7200)).toBe('2h 0m');
+  });
+
+  it('formats minutes only when under an hour', () => {
+    expect(formatDuration(1800)).toBe('30m');
+    expect(formatDuration(60)).toBe('1m');
+  });
+
+  it('returns 0m for zero or negative', () => {
+    expect(formatDuration(0)).toBe('0m');
+    expect(formatDuration(-100)).toBe('0m');
+  });
+});
+
+describe('formatTimer', () => {
+  it('formats as HH:MM:SS', () => {
+    expect(formatTimer(0)).toBe('00:00:00');
+    expect(formatTimer(61)).toBe('00:01:01');
+    expect(formatTimer(3661)).toBe('01:01:01');
+    expect(formatTimer(36000)).toBe('10:00:00');
+  });
+
+  it('handles negative as 00:00:00', () => {
+    expect(formatTimer(-5)).toBe('00:00:00');
+  });
+});
+
+describe('getActiveClockSeconds', () => {
+  it('returns 0 for null event', () => {
+    expect(getActiveClockSeconds(null, Date.now())).toBe(0);
+  });
+
+  it('returns 0 for ended event', () => {
+    const event = { startTime: 1000, endTime: 5000 };
+    expect(getActiveClockSeconds(event, 10000)).toBe(0);
+  });
+
+  it('computes elapsed seconds for active event', () => {
+    const startTime = 1000;
+    const now = 61000; // 60 seconds later
+    const event = { startTime, endTime: null };
+    expect(getActiveClockSeconds(event, now)).toBe(60);
+  });
+
+  it('guards against negative elapsed time (future startTime)', () => {
+    const event = { startTime: 100000, endTime: null };
+    expect(getActiveClockSeconds(event, 1000)).toBe(0);
+  });
+});
+
+describe('startOfDay', () => {
+  it('sets time to midnight', () => {
+    const date = new Date(2026, 4, 15, 14, 30, 45);
+    const result = startOfDay(date);
+    expect(result.getHours()).toBe(0);
+    expect(result.getMinutes()).toBe(0);
+    expect(result.getSeconds()).toBe(0);
+    expect(result.getMilliseconds()).toBe(0);
+  });
+});
+
+describe('endOfDay', () => {
+  it('sets time to 23:59:59.999', () => {
+    const date = new Date(2026, 4, 15, 14, 30, 45);
+    const result = endOfDay(date);
+    expect(result.getHours()).toBe(23);
+    expect(result.getMinutes()).toBe(59);
+    expect(result.getSeconds()).toBe(59);
+    expect(result.getMilliseconds()).toBe(999);
+  });
+});
+
+describe('toDateString', () => {
+  it('returns YYYY-MM-DD format', () => {
+    const date = new Date(2026, 4, 15);
+    expect(toDateString(date)).toBe('2026-05-15');
+  });
+
+  it('pads single-digit month and day', () => {
+    const date = new Date(2026, 0, 5);
+    expect(toDateString(date)).toBe('2026-01-05');
+  });
+});

--- a/src/lib/timeUtils.ts
+++ b/src/lib/timeUtils.ts
@@ -49,3 +49,12 @@ export function toDateString(date: Date): string {
   const d = String(date.getDate()).padStart(2, '0');
   return `${y}-${m}-${d}`;
 }
+
+/** Compute elapsed seconds for an active clock event */
+export function getActiveClockSeconds(
+  event: { startTime: number; endTime: number | null } | null,
+  nowMs: number,
+): number {
+  if (!event || event.endTime != null) return 0;
+  return Math.max(0, Math.floor((nowMs - event.startTime) / 1000));
+}

--- a/src/lib/useClockDocumentTitle.ts
+++ b/src/lib/useClockDocumentTitle.ts
@@ -1,0 +1,32 @@
+/**
+ * useClockDocumentTitle — Sync document.title with clock-in state.
+ *
+ * When clocked in, the tab title shows live elapsed time (e.g. "01:23:45 · Dashboard · TimeHuddle").
+ * When not clocked in, it shows the page title only (e.g. "Dashboard · TimeHuddle").
+ * On unmount, resets to the default static title.
+ */
+import { useEffect } from 'react';
+
+import { useTeam } from './TeamContext';
+import { formatTimer, getActiveClockSeconds } from './timeUtils';
+
+const DEFAULT_TITLE = 'TimeHuddle — Team Time Tracking';
+
+export function useClockDocumentTitle(pageTitle: string): void {
+  const { activeClockEvent, currentTime } = useTeam();
+
+  useEffect(() => {
+    if (activeClockEvent) {
+      const elapsed = getActiveClockSeconds(activeClockEvent, currentTime);
+      document.title = `${formatTimer(elapsed)} · ${pageTitle} · TimeHuddle`;
+    } else {
+      document.title = `${pageTitle} · TimeHuddle`;
+    }
+  }, [activeClockEvent, currentTime, pageTitle]);
+
+  useEffect(() => {
+    return () => {
+      document.title = DEFAULT_TITLE;
+    };
+  }, []);
+}

--- a/src/ui/AppHeader.tsx
+++ b/src/ui/AppHeader.tsx
@@ -2,14 +2,16 @@
  * AppHeader — Sticky top bar.
  *
  * Left  : hamburger (mobile), current page title
- * Right : ThemeToggle, UserDropdown
+ * Right : clock-in timer (if active), TeamSelector, UserDropdown
  */
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button, Text } from '@mieweb/ui';
 import React from 'react';
 
+import { useClockDocumentTitle } from '../lib/useClockDocumentTitle';
 import { useSidebar } from './AppLayout';
+import { ClockInHeaderTimer } from './ClockInHeaderTimer';
 import { TeamSelector } from './TeamSelector';
 import { UserDropdown } from './UserDropdown';
 
@@ -20,11 +22,13 @@ interface AppHeaderProps {
 export const AppHeader: React.FC<AppHeaderProps> = ({ title }) => {
   const { openMobile } = useSidebar();
 
+  useClockDocumentTitle(title);
+
   return (
     <header className="app-header sticky top-0 z-30 flex shrink-0 flex-col justify-end border-b border-neutral-200 bg-white/80 backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/80">
       <div className="flex h-16 items-center justify-between gap-4 px-4">
         {/* ── Left ── */}
-        <div className="flex items-center gap-3">
+        <div className="flex min-w-0 items-center gap-3">
           {/* Mobile hamburger */}
           <Button
             variant="ghost"
@@ -37,13 +41,15 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ title }) => {
           </Button>
 
           {/* Page title */}
-          <Text as="h1" size="base" weight="semibold" className="tracking-tight">
+          <Text as="h1" size="base" weight="semibold" className="truncate tracking-tight">
             {title}
           </Text>
         </div>
 
         {/* ── Right ── */}
         <div className="flex items-center gap-2">
+          {/* Clock-in timer (visible when clocked in) */}
+          <ClockInHeaderTimer />
           <TeamSelector />
           <UserDropdown />
         </div>

--- a/src/ui/ClockInHeaderTimer.tsx
+++ b/src/ui/ClockInHeaderTimer.tsx
@@ -1,0 +1,32 @@
+/**
+ * ClockInHeaderTimer — Compact elapsed timer for the app header.
+ *
+ * Displays only when the user has an active clock event. Uses the Timer
+ * component with an animated clock icon and live HH:MM:SS display.
+ */
+import React from 'react';
+
+import { useTeam } from '../lib/TeamContext';
+import { formatTimer, getActiveClockSeconds } from '../lib/timeUtils';
+import { TimerRoot, TimerIcon, TimerDisplay } from './Timer';
+
+export const ClockInHeaderTimer: React.FC = () => {
+  const { activeClockEvent, currentTime } = useTeam();
+
+  if (!activeClockEvent) return null;
+
+  const elapsedSeconds = getActiveClockSeconds(activeClockEvent, currentTime);
+  const display = formatTimer(elapsedSeconds);
+
+  return (
+    <TimerRoot
+      variant="success"
+      size="md"
+      aria-live="polite"
+      aria-label={`Clocked in, elapsed time ${display}`}
+    >
+      <TimerIcon size="md" loading />
+      <TimerDisplay time={display} size="md" />
+    </TimerRoot>
+  );
+};

--- a/src/ui/Timer.tsx
+++ b/src/ui/Timer.tsx
@@ -1,0 +1,133 @@
+/**
+ * Timer — A flexible timer display component inspired by cult-ui/timer.
+ *
+ * Supports multiple variants (default, outline, ghost, success) and sizes (sm, md, lg).
+ * Uses compound components for flexibility: TimerRoot, TimerIcon, TimerDisplay.
+ */
+import { faClock } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import type { IconDefinition } from '@fortawesome/fontawesome-svg-core';
+import React from 'react';
+
+// ─── Variant & Size Styles ───────────────────────────────────────────────────
+
+type TimerVariant = 'default' | 'outline' | 'ghost' | 'success';
+type TimerSize = 'sm' | 'md' | 'lg';
+
+const rootVariantClasses: Record<TimerVariant, string> = {
+  default:
+    'bg-white text-neutral-900 border border-neutral-200 shadow-sm dark:bg-neutral-800 dark:text-neutral-100 dark:border-neutral-700',
+  outline:
+    'border border-neutral-300 bg-transparent text-neutral-700 dark:border-neutral-600 dark:text-neutral-300',
+  ghost: 'bg-transparent text-neutral-700 dark:text-neutral-300',
+  success:
+    'bg-green-50 text-green-700 border border-green-200 dark:bg-green-950/40 dark:text-green-300 dark:border-green-800',
+};
+
+const rootSizeClasses: Record<TimerSize, string> = {
+  sm: 'text-xs px-2 py-1 gap-1.5',
+  md: 'text-sm px-2.5 py-1.5 gap-2',
+  lg: 'text-base px-3 py-2 gap-2.5',
+};
+
+const iconSizeClasses: Record<TimerSize, string> = {
+  sm: 'text-[10px]',
+  md: 'text-xs',
+  lg: 'text-sm',
+};
+
+const displaySizeClasses: Record<TimerSize, string> = {
+  sm: 'text-xs',
+  md: 'text-sm',
+  lg: 'text-base',
+};
+
+// ─── TimerRoot ───────────────────────────────────────────────────────────────
+
+export interface TimerRootProps extends React.HTMLAttributes<HTMLDivElement> {
+  variant?: TimerVariant;
+  size?: TimerSize;
+  loading?: boolean;
+}
+
+export const TimerRoot = React.forwardRef<HTMLDivElement, TimerRootProps>(
+  ({ variant = 'default', size = 'md', className = '', children, ...props }, ref) => {
+    return (
+      <div
+        ref={ref}
+        className={`inline-flex items-center rounded-full font-medium transition-all duration-200 ${rootVariantClasses[variant]} ${rootSizeClasses[size]} ${className}`}
+        {...props}
+      >
+        {children}
+      </div>
+    );
+  },
+);
+TimerRoot.displayName = 'TimerRoot';
+
+// ─── TimerIcon ───────────────────────────────────────────────────────────────
+
+export interface TimerIconProps extends React.HTMLAttributes<HTMLSpanElement> {
+  size?: TimerSize;
+  loading?: boolean;
+  icon?: IconDefinition;
+}
+
+export const TimerIcon = React.forwardRef<HTMLSpanElement, TimerIconProps>(
+  ({ size = 'md', loading = false, icon = faClock, className = '', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={`flex items-center justify-center ${iconSizeClasses[size]} ${loading ? 'animate-spin' : ''} ${className}`}
+        {...props}
+      >
+        <FontAwesomeIcon icon={icon} />
+      </span>
+    );
+  },
+);
+TimerIcon.displayName = 'TimerIcon';
+
+// ─── TimerDisplay ────────────────────────────────────────────────────────────
+
+export interface TimerDisplayProps extends React.HTMLAttributes<HTMLSpanElement> {
+  time: string;
+  size?: TimerSize;
+  label?: string;
+}
+
+export const TimerDisplay = React.forwardRef<HTMLSpanElement, TimerDisplayProps>(
+  ({ time, size = 'md', label, className = '', ...props }, ref) => {
+    return (
+      <span
+        ref={ref}
+        className={`font-mono tabular-nums tracking-tight ${displaySizeClasses[size]} ${className}`}
+        aria-label={label}
+        {...props}
+      >
+        {time}
+      </span>
+    );
+  },
+);
+TimerDisplay.displayName = 'TimerDisplay';
+
+// ─── Timer (Convenience Compound) ────────────────────────────────────────────
+
+export interface TimerProps extends Omit<TimerRootProps, 'children'> {
+  time: string;
+  icon?: IconDefinition;
+  showIcon?: boolean;
+}
+
+export const Timer = React.forwardRef<HTMLDivElement, TimerProps>(
+  ({ time, icon, showIcon = true, variant, size, loading, ...props }, ref) => {
+    return (
+      <TimerRoot ref={ref} variant={variant} size={size} loading={loading} {...props}>
+        {showIcon && <TimerIcon size={size} loading={loading} icon={icon} />}
+        <TimerDisplay time={time} size={size} />
+      </TimerRoot>
+    );
+  },
+);
+Timer.displayName = 'Timer';


### PR DESCRIPTION
While clocked in, display a live HH:MM:SS timer in the app header and update the browser tab title every second. Resets on clock-out or logout.

https://github.com/user-attachments/assets/598f155f-d545-4b41-951a-61ada550be6a

