### PR TITLE
feat: implement AdminDayGroup component for collapsible session summary in admin timesheet

### DIFF
--- a/src/features/teams/AdminDayGroup.test.tsx
+++ b/src/features/teams/AdminDayGroup.test.tsx
@@ -1,0 +1,214 @@
+import { cleanup, fireEvent, render, screen } from '@testing-library/react';
+import type { ReactNode } from 'react';
+import { afterEach, describe, expect, it, vi } from 'vitest';
+
+import { type ClockEvent } from '../../lib/api';
+import { AdminDayGroup } from './AdminDayGroup';
+
+afterEach(() => {
+  cleanup();
+});
+
+vi.mock('@fortawesome/react-fontawesome', () => ({
+  FontAwesomeIcon: () => null,
+}));
+
+vi.mock('@mieweb/ui', () => ({
+  Badge: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+  Button: ({
+    children,
+    onClick,
+    'aria-label': ariaLabel,
+  }: {
+    children: ReactNode;
+    onClick?: (e: React.MouseEvent) => void;
+    'aria-label'?: string;
+  }) => (
+    <button type="button" onClick={onClick} aria-label={ariaLabel}>
+      {children}
+    </button>
+  ),
+  TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
+  TableRow: ({
+    children,
+    onClick,
+  }: {
+    children: ReactNode;
+    onClick?: () => void;
+  }) => <tr onClick={onClick}>{children}</tr>,
+  Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
+}));
+
+vi.mock('../clock/TimesheetRow', () => ({
+  TimesheetRow: ({ session }: { session: ClockEvent }) => (
+    <tr data-testid="timesheet-row" data-session-id={session.id} />
+  ),
+}));
+
+// ─── Fixtures ──────────────────────────────────────────────────────────────────
+
+const TEAMS = [{ id: 'team-1', name: 'Alpha Team' }];
+
+function buildSession(overrides: Partial<ClockEvent> = {}): ClockEvent {
+  return {
+    id: 'session-1',
+    userId: 'u1',
+    teamId: 'team-1',
+    startTime: new Date('2026-05-19T09:00:00').getTime(),
+    endTime: new Date('2026-05-19T17:00:00').getTime(),
+    accumulatedTime: 8 * 3600,
+    breaks: [],
+    ...overrides,
+  };
+}
+
+function renderGroup(props: Partial<Parameters<typeof AdminDayGroup>[0]> = {}) {
+  const defaults = {
+    sessions: [buildSession()],
+    teams: TEAMS,
+    onEdit: vi.fn(),
+    isExpanded: false,
+    onToggle: vi.fn(),
+  };
+  return render(
+    <table>
+      <tbody>
+        <AdminDayGroup {...defaults} {...props} />
+      </tbody>
+    </table>,
+  );
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('AdminDayGroup', () => {
+  describe('summary row (collapsed)', () => {
+    it('shows aggregated duration for a single session', () => {
+      renderGroup();
+      expect(screen.getByText('8h 0m')).toBeTruthy();
+    });
+
+    it('sums duration across multiple sessions', () => {
+      const s1 = buildSession({
+        id: 's1',
+        startTime: new Date('2026-05-19T08:00:00').getTime(),
+        endTime: new Date('2026-05-19T12:00:00').getTime(),
+        accumulatedTime: 4 * 3600,
+      });
+      const s2 = buildSession({
+        id: 's2',
+        startTime: new Date('2026-05-19T13:00:00').getTime(),
+        endTime: new Date('2026-05-19T17:00:00').getTime(),
+        accumulatedTime: 4 * 3600,
+      });
+      renderGroup({ sessions: [s1, s2] });
+      expect(screen.getByText('8h 0m')).toBeTruthy();
+    });
+
+    it('shows session count for a completed day', () => {
+      renderGroup({ sessions: [buildSession()] });
+      expect(screen.getByText('1 session')).toBeTruthy();
+    });
+
+    it('shows plural session count for multiple sessions', () => {
+      renderGroup({
+        sessions: [buildSession({ id: 's1' }), buildSession({ id: 's2' })],
+      });
+      expect(screen.getByText('2 sessions')).toBeTruthy();
+    });
+
+    it('shows Active badge when any session has no endTime', () => {
+      renderGroup({ sessions: [buildSession({ endTime: null })] });
+      expect(screen.getByText('Active')).toBeTruthy();
+      expect(screen.queryByText('1 session')).toBeNull();
+    });
+
+    it('shows Active badge when one of multiple sessions is still open', () => {
+      const finished = buildSession({ id: 's1' });
+      const active = buildSession({ id: 's2', endTime: null, accumulatedTime: 0 });
+      renderGroup({ sessions: [finished, active] });
+      expect(screen.getByText('Active')).toBeTruthy();
+    });
+
+    it('shows team name when all sessions are on the same team', () => {
+      renderGroup();
+      expect(screen.getByText('Alpha Team')).toBeTruthy();
+    });
+
+    it('shows "Multiple" when sessions span more than one team', () => {
+      const s1 = buildSession({ id: 's1', teamId: 'team-1' });
+      const s2 = buildSession({ id: 's2', teamId: 'team-2' });
+      const teams = [
+        { id: 'team-1', name: 'Alpha' },
+        { id: 'team-2', name: 'Beta' },
+      ];
+      renderGroup({ sessions: [s1, s2], teams });
+      expect(screen.getByText('Multiple')).toBeTruthy();
+    });
+
+    it('does not render individual session rows when collapsed', () => {
+      renderGroup({ isExpanded: false });
+      expect(screen.queryAllByTestId('timesheet-row')).toHaveLength(0);
+    });
+
+    it('shows "Expand day" aria-label on chevron when collapsed', () => {
+      renderGroup({ isExpanded: false });
+      expect(screen.getByRole('button', { name: 'Expand day' })).toBeTruthy();
+    });
+
+    it('shows "Collapse day" aria-label on chevron when expanded', () => {
+      renderGroup({ isExpanded: true });
+      expect(screen.getByRole('button', { name: 'Collapse day' })).toBeTruthy();
+    });
+  });
+
+  describe('expand / collapse behaviour', () => {
+    it('calls onToggle when the summary row is clicked', () => {
+      const onToggle = vi.fn();
+      renderGroup({ onToggle });
+      fireEvent.click(screen.getAllByRole('row')[0]);
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('calls onToggle when the chevron button is clicked', () => {
+      const onToggle = vi.fn();
+      renderGroup({ onToggle, isExpanded: false });
+      fireEvent.click(screen.getByRole('button', { name: 'Expand day' }));
+      expect(onToggle).toHaveBeenCalledTimes(1);
+    });
+
+    it('renders one TimesheetRow per session when expanded', () => {
+      const sessions = [buildSession({ id: 's1' }), buildSession({ id: 's2' })];
+      renderGroup({ sessions, isExpanded: true });
+      expect(screen.getAllByTestId('timesheet-row')).toHaveLength(2);
+    });
+
+    it('hides session rows when collapsed after being given expanded=false', () => {
+      const sessions = [buildSession({ id: 's1' }), buildSession({ id: 's2' })];
+      renderGroup({ sessions, isExpanded: false });
+      expect(screen.queryAllByTestId('timesheet-row')).toHaveLength(0);
+    });
+
+    it('session rows carry the correct session id when expanded', () => {
+      const sessions = [
+        buildSession({ id: 'sess-a' }),
+        buildSession({ id: 'sess-b' }),
+      ];
+      renderGroup({ sessions, isExpanded: true });
+      const rows = screen.getAllByTestId('timesheet-row');
+      const ids = rows.map((r) => r.getAttribute('data-session-id'));
+      expect(ids).toContain('sess-a');
+      expect(ids).toContain('sess-b');
+    });
+  });
+
+  describe('onEdit forwarding', () => {
+    it('passes onEdit to each expanded TimesheetRow', () => {
+      // The mock TimesheetRow renders a data-session-id attribute,
+      // confirming the correct session is forwarded via props.
+      const session = buildSession({ id: 'target-session' });
+      renderGroup({ sessions: [session], isExpanded: true });
+      expect(screen.getByTestId('timesheet-row').dataset.sessionId).toBe('target-session');
+    });
+  });
+});

--- a/src/features/teams/AdminDayGroup.test.tsx
+++ b/src/features/teams/AdminDayGroup.test.tsx
@@ -29,13 +29,9 @@ vi.mock('@mieweb/ui', () => ({
     </button>
   ),
   TableCell: ({ children }: { children: ReactNode }) => <td>{children}</td>,
-  TableRow: ({
-    children,
-    onClick,
-  }: {
-    children: ReactNode;
-    onClick?: () => void;
-  }) => <tr onClick={onClick}>{children}</tr>,
+  TableRow: ({ children, onClick }: { children: ReactNode; onClick?: () => void }) => (
+    <tr onClick={onClick}>{children}</tr>
+  ),
   Text: ({ children }: { children: ReactNode }) => <span>{children}</span>,
 }));
 
@@ -190,10 +186,7 @@ describe('AdminDayGroup', () => {
     });
 
     it('session rows carry the correct session id when expanded', () => {
-      const sessions = [
-        buildSession({ id: 'sess-a' }),
-        buildSession({ id: 'sess-b' }),
-      ];
+      const sessions = [buildSession({ id: 'sess-a' }), buildSession({ id: 'sess-b' })];
       renderGroup({ sessions, isExpanded: true });
       const rows = screen.getAllByTestId('timesheet-row');
       const ids = rows.map((r) => r.getAttribute('data-session-id'));

--- a/src/features/teams/AdminDayGroup.tsx
+++ b/src/features/teams/AdminDayGroup.tsx
@@ -1,0 +1,135 @@
+/**
+ * AdminDayGroup — Renders a collapsible summary row for a single calendar day
+ * in the admin timesheet, with all individual sessions expandable below it.
+ *
+ * Summary row shows aggregated values across all sessions that day.
+ * Clicking the row (or the chevron) toggles the expanded detail view, which
+ * renders one TimesheetRow per session — identical to the personal timesheet.
+ */
+import { faChevronDown, faChevronRight } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Badge, Button, TableCell, TableRow, Text } from '@mieweb/ui';
+import React from 'react';
+
+import { type ClockEvent } from '../../lib/api';
+import { formatDate, formatDuration, formatTime } from '../../lib/timeUtils';
+import { TimesheetRow } from '../clock/TimesheetRow';
+
+// ─── Types ────────────────────────────────────────────────────────────────────
+
+interface Team {
+  id: string;
+  name: string;
+}
+
+interface Props {
+  sessions: ClockEvent[];
+  teams: Team[];
+  onEdit: (session: ClockEvent) => void;
+  isExpanded: boolean;
+  onToggle: () => void;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+function getSessionWorkSeconds(session: ClockEvent, now: number): number {
+  if (session.endTime === null) {
+    if (typeof session.workSeconds === 'number') return Math.max(0, session.workSeconds);
+    const accumulated = Math.max(0, session.accumulatedTime ?? 0);
+    if (session.isPaused) return accumulated;
+    return accumulated + Math.max(0, Math.floor((now - session.startTime) / 1000));
+  }
+  const accumulated = Math.max(0, session.accumulatedTime ?? 0);
+  if (accumulated > 0) return accumulated;
+  return Math.max(0, Math.floor((session.endTime - session.startTime) / 1000));
+}
+
+// ─── Component ────────────────────────────────────────────────────────────────
+
+export const AdminDayGroup: React.FC<Props> = ({ sessions, teams, onEdit, isExpanded, onToggle }) => {
+  const now = Date.now();
+
+  const hasActiveSession = sessions.some((s) => s.endTime === null);
+  const totalWorkSeconds = sessions.reduce((sum, s) => sum + getSessionWorkSeconds(s, now), 0);
+
+  // Earliest clock-in of the day
+  const earliestStart = Math.min(...sessions.map((s) => s.originalStartTime ?? s.startTime));
+
+  // Latest clock-out (null if any session is still active)
+  const latestEnd = hasActiveSession
+    ? null
+    : Math.max(...sessions.map((s) => s.endTime as number));
+
+  // Team: single name if all sessions share a team, otherwise "Multiple"
+  const teamIds = [...new Set(sessions.map((s) => s.teamId))];
+  const teamLabel =
+    teamIds.length === 1
+      ? (teams.find((t) => t.id === teamIds[0])?.name ?? teamIds[0])
+      : 'Multiple';
+
+  // Sessions sorted descending for the expanded view (newest first)
+  const sortedSessions = sessions
+    .slice()
+    .sort(
+      (a, b) =>
+        (b.originalStartTime ?? b.startTime) - (a.originalStartTime ?? a.startTime),
+    );
+
+  return (
+    <>
+      {/* ── Day summary row ── */}
+      <TableRow
+        className="cursor-pointer hover:bg-neutral-50 dark:hover:bg-neutral-800/50"
+        onClick={onToggle}
+      >
+        <TableCell>{formatDate(new Date(earliestStart), true)}</TableCell>
+        <TableCell>{formatTime(new Date(earliestStart))}</TableCell>
+        <TableCell>
+          {latestEnd === null ? (
+            <Text variant="muted" size="xs">
+              —
+            </Text>
+          ) : (
+            formatTime(new Date(latestEnd))
+          )}
+        </TableCell>
+        <TableCell className="font-mono">{formatDuration(totalWorkSeconds)}</TableCell>
+        <TableCell>{teamLabel}</TableCell>
+        <TableCell>
+          {hasActiveSession ? (
+            <Badge variant="success" size="sm">
+              <span className="mr-1 inline-block h-1.5 w-1.5 animate-pulse rounded-full bg-green-500" />
+              Active
+            </Badge>
+          ) : (
+            <Text variant="muted" size="xs">
+              {sessions.length} {sessions.length === 1 ? 'session' : 'sessions'}
+            </Text>
+          )}
+        </TableCell>
+        <TableCell className="text-right">
+          <Button
+            variant="ghost"
+            size="icon"
+            aria-label={isExpanded ? 'Collapse day' : 'Expand day'}
+            onClick={(e) => {
+              e.stopPropagation();
+              onToggle();
+            }}
+          >
+            <FontAwesomeIcon
+              icon={isExpanded ? faChevronDown : faChevronRight}
+              className="text-sm"
+            />
+          </Button>
+        </TableCell>
+      </TableRow>
+
+      {/* ── Expanded session rows ── */}
+      {isExpanded &&
+        sortedSessions.map((session) => (
+          <TimesheetRow key={session.id} session={session} teams={teams} onEdit={onEdit} />
+        ))}
+    </>
+  );
+};

--- a/src/features/teams/AdminDayGroup.tsx
+++ b/src/features/teams/AdminDayGroup.tsx
@@ -46,7 +46,13 @@ function getSessionWorkSeconds(session: ClockEvent, now: number): number {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export const AdminDayGroup: React.FC<Props> = ({ sessions, teams, onEdit, isExpanded, onToggle }) => {
+export const AdminDayGroup: React.FC<Props> = ({
+  sessions,
+  teams,
+  onEdit,
+  isExpanded,
+  onToggle,
+}) => {
   const now = Date.now();
 
   const hasActiveSession = sessions.some((s) => s.endTime === null);
@@ -56,9 +62,7 @@ export const AdminDayGroup: React.FC<Props> = ({ sessions, teams, onEdit, isExpa
   const earliestStart = Math.min(...sessions.map((s) => s.originalStartTime ?? s.startTime));
 
   // Latest clock-out (null if any session is still active)
-  const latestEnd = hasActiveSession
-    ? null
-    : Math.max(...sessions.map((s) => s.endTime as number));
+  const latestEnd = hasActiveSession ? null : Math.max(...sessions.map((s) => s.endTime as number));
 
   // Team: single name if all sessions share a team, otherwise "Multiple"
   const teamIds = [...new Set(sessions.map((s) => s.teamId))];
@@ -70,10 +74,7 @@ export const AdminDayGroup: React.FC<Props> = ({ sessions, teams, onEdit, isExpa
   // Sessions sorted descending for the expanded view (newest first)
   const sortedSessions = sessions
     .slice()
-    .sort(
-      (a, b) =>
-        (b.originalStartTime ?? b.startTime) - (a.originalStartTime ?? a.startTime),
-    );
+    .sort((a, b) => (b.originalStartTime ?? b.startTime) - (a.originalStartTime ?? a.startTime));
 
   return (
     <>

--- a/src/features/teams/AdminTimesheetPanel.tsx
+++ b/src/features/teams/AdminTimesheetPanel.tsx
@@ -9,7 +9,7 @@
  *   • The backend allows only team admins to VIEW another member's sessions.
  *   • Edit/delete is allowed only for admins (enforced server-side).
  */
-import { faCalendar } from '@fortawesome/free-solid-svg-icons';
+import { faCalendar, faChevronDown, faChevronUp } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import {
   Alert,
@@ -38,7 +38,7 @@ import React, { useCallback, useEffect, useMemo, useState } from 'react';
 import { ApiError, clockApi, type ClockEvent } from '../../lib/api';
 import { formatDuration } from '../../lib/timeUtils';
 import { type TeamMember } from '../../lib/api';
-import { TimesheetRow } from '../clock/TimesheetRow';
+import { AdminDayGroup } from './AdminDayGroup';
 import {
   fromLocalDateTimeInputValue,
   getDateRange,
@@ -88,6 +88,7 @@ function getSessionWorkSeconds(session: ClockEvent, now: number): number {
 
 export const AdminTimesheetPanel: React.FC<Props> = ({ members, selectedTeamId, teams }) => {
   const [selectedMemberId, setSelectedMemberId] = useState<string>('');
+  const [expandedDays, setExpandedDays] = useState<Set<string>>(new Set());
   const [preset, setPreset] = useState<Preset>('week');
   const [customStart, setCustomStart] = useState('');
   const [customEnd, setCustomEnd] = useState('');
@@ -158,6 +159,46 @@ export const AdminTimesheetPanel: React.FC<Props> = ({ members, selectedTeamId, 
       ? data.sessions.filter((s) => s.teamId === selectedTeamId)
       : data.sessions;
   }, [data, selectedTeamId]);
+
+  // Group filtered sessions by calendar day (descending date order)
+  const groupedByDay = useMemo(() => {
+    const map = new Map<string, ClockEvent[]>();
+    for (const session of filteredSessions) {
+      const dayKey = new Date(session.originalStartTime ?? session.startTime)
+        .toISOString()
+        .slice(0, 10);
+      const bucket = map.get(dayKey);
+      if (bucket) {
+        bucket.push(session);
+      } else {
+        map.set(dayKey, [session]);
+      }
+    }
+    // Sort entries descending by date
+    return new Map([...map.entries()].sort((a, b) => b[0].localeCompare(a[0])));
+  }, [filteredSessions]);
+
+  const allExpanded = expandedDays.size > 0;
+
+  const toggleExpandAll = useCallback(() => {
+    if (allExpanded) {
+      setExpandedDays(new Set());
+    } else {
+      setExpandedDays(new Set(groupedByDay.keys()));
+    }
+  }, [allExpanded, groupedByDay]);
+
+  const toggleDay = useCallback((dayKey: string) => {
+    setExpandedDays((prev) => {
+      const next = new Set(prev);
+      if (next.has(dayKey)) {
+        next.delete(dayKey);
+      } else {
+        next.add(dayKey);
+      }
+      return next;
+    });
+  }, []);
 
   // Recompute summary from filtered sessions
   const filteredSummary = useMemo(() => {
@@ -392,8 +433,22 @@ export const AdminTimesheetPanel: React.FC<Props> = ({ members, selectedTeamId, 
       {/* Sessions table */}
       {data && filteredSessions.length > 0 && (
         <Card padding="none">
-          <CardHeader className="px-5 py-3">
-            <CardTitle className="text-sm">Sessions ({filteredSessions.length})</CardTitle>
+          <CardHeader className="flex items-center justify-between px-5 py-3">
+            <CardTitle className="text-sm">
+              {groupedByDay.size} {groupedByDay.size === 1 ? 'day' : 'days'} &middot; {filteredSessions.length} sessions
+            </CardTitle>
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={toggleExpandAll}
+              aria-label={allExpanded ? 'Collapse all days' : 'Expand all days'}
+            >
+              <FontAwesomeIcon
+                icon={allExpanded ? faChevronUp : faChevronDown}
+                className="mr-1.5 text-xs"
+              />
+              {allExpanded ? 'Collapse All' : 'Expand All'}
+            </Button>
           </CardHeader>
           <CardContent className="p-0">
             <Table responsive>
@@ -409,8 +464,15 @@ export const AdminTimesheetPanel: React.FC<Props> = ({ members, selectedTeamId, 
                 </TableRow>
               </TableHeader>
               <TableBody>
-                {filteredSessions.map((s) => (
-                  <TimesheetRow key={s.id} session={s} teams={teams} onEdit={openSessionDialog} />
+                {[...groupedByDay.entries()].map(([dayKey, daySessions]) => (
+                  <AdminDayGroup
+                    key={dayKey}
+                    sessions={daySessions}
+                    teams={teams}
+                    onEdit={openSessionDialog}
+                    isExpanded={expandedDays.has(dayKey)}
+                    onToggle={() => toggleDay(dayKey)}
+                  />
                 ))}
               </TableBody>
             </Table>

--- a/src/features/teams/AdminTimesheetPanel.tsx
+++ b/src/features/teams/AdminTimesheetPanel.tsx
@@ -435,7 +435,8 @@ export const AdminTimesheetPanel: React.FC<Props> = ({ members, selectedTeamId, 
         <Card padding="none">
           <CardHeader className="flex items-center justify-between px-5 py-3">
             <CardTitle className="text-sm">
-              {groupedByDay.size} {groupedByDay.size === 1 ? 'day' : 'days'} &middot; {filteredSessions.length} sessions
+              {groupedByDay.size} {groupedByDay.size === 1 ? 'day' : 'days'} &middot;{' '}
+              {filteredSessions.length} sessions
             </CardTitle>
             <Button
               variant="outline"


### PR DESCRIPTION
This pull request introduces a new `AdminDayGroup` component to the admin timesheet, providing a grouped, collapsible day-by-day view of sessions. It replaces the previous flat session list with a more organized table, allowing admins to expand/collapse all days at once or individually. Comprehensive tests for the new component are also included.

**Admin timesheet UI improvements:**

* Added the `AdminDayGroup` component, which groups sessions by calendar day, displays a summary row for each day, and allows expanding to view individual sessions. The summary shows total duration, session count, team info, and active status.
* Updated `AdminTimesheetPanel.tsx` to group sessions by day, render one `AdminDayGroup` per day, and manage expanded/collapsed state for each day. [[1]](diffhunk://#diff-09e1876a74e6d688db083ab9433fa6fe74930a244018c574b851217f1f49cc6bL41-R41) [[2]](diffhunk://#diff-09e1876a74e6d688db083ab9433fa6fe74930a244018c574b851217f1f49cc6bR163-R202) [[3]](diffhunk://#diff-09e1876a74e6d688db083ab9433fa6fe74930a244018c574b851217f1f49cc6bL412-R475)

**Expand/collapse controls:**

* Added "Expand All"/"Collapse All" button to the sessions table, allowing admins to expand or collapse all days at once, with corresponding UI and aria-labels. [[1]](diffhunk://#diff-09e1876a74e6d688db083ab9433fa6fe74930a244018c574b851217f1f49cc6bR91) [[2]](diffhunk://#diff-09e1876a74e6d688db083ab9433fa6fe74930a244018c574b851217f1f49cc6bL395-R451)

**Testing:**

* Added a comprehensive test suite for `AdminDayGroup`, covering summary rendering, session aggregation, expand/collapse behavior, and prop forwarding.

**Minor:**

* Updated icon imports to include chevron icons used for expand/collapse controls.