### PR TITLE
Decouple clocking from teams and streamline timesheet rows

### DIFF
--- a/.attic/OzwellWidget.tsx
+++ b/.attic/OzwellWidget.tsx
@@ -1150,7 +1150,7 @@ export const OzwellWidget: React.FC = () => {
            * Rules enforced here (per product requirements):
            *   1. Never creates a ticket — use create_ticket first if needed.
            *   2. Ticket must belong to the currently selected team.
-           *   3. User must be clocked in to the currently selected team.
+           *   3. User must have an active clock event (team-scoped or user-scoped).
            *   4. Reuses an existing work item for today if one exists (idempotent).
            */
           case 'start_ticket_timer': {
@@ -1209,7 +1209,7 @@ export const OzwellWidget: React.FC = () => {
               ticketId = match.id;
             }
 
-            // ── 2. Verify user is clocked in to this team ─────────────────────
+            // ── 2. Verify user is clocked in (team-scoped or user-scoped) ─────
             if (!ctx.activeClockEvent) {
               debugRespond({
                 success: false,
@@ -1217,7 +1217,7 @@ export const OzwellWidget: React.FC = () => {
               });
               return;
             }
-            if (ctx.activeClockEvent.teamId !== teamId) {
+            if (ctx.activeClockEvent.teamId && ctx.activeClockEvent.teamId !== teamId) {
               const clockedTeam = ctx.teams.find((t) => t.id === ctx.activeClockEvent?.teamId);
               debugRespond({
                 success: false,

--- a/.attic/OzwellWidget.tsx
+++ b/.attic/OzwellWidget.tsx
@@ -815,26 +815,14 @@ export const OzwellWidget: React.FC = () => {
           }
 
           case 'clock_in': {
-            if (!ctx.selectedTeamId) {
-              const available = ctx.teams.map((t) => `"${t.name}"`).join(', ');
-              debugRespond({
-                success: false,
-                error: `No team selected. Use switch_team first. Available teams: ${available}`,
-              });
-              return;
-            }
-            const event = await clockApi.start(ctx.selectedTeamId);
+            const event = await clockApi.start();
             ctx.refetchClock();
             debugRespond({ success: true, data: event });
             break;
           }
 
           case 'clock_out': {
-            if (!ctx.selectedTeamId) {
-              debugRespond({ success: false, error: 'No team selected' });
-              return;
-            }
-            const stoppedEvent = await clockApi.stop(ctx.selectedTeamId);
+            const stoppedEvent = await clockApi.stop();
             ctx.refetchClock();
             debugRespond({ success: true, data: stoppedEvent });
             break;

--- a/backend/src/controllers/clock.controller.ts
+++ b/backend/src/controllers/clock.controller.ts
@@ -6,24 +6,21 @@ import type { ClockBreak } from "../models/clock.model.js";
 export const clockController = {
   async start(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId } = req.body as { teamId: string };
-    const result = await clockService.start(userId, teamId);
+    const result = await clockService.start(userId);
     if (result === "forbidden") return reply.status(403).send({ error: "Forbidden" });
     return { event: result };
   },
 
   async stop(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId } = req.body as { teamId: string };
-    const result = await clockService.stop(userId, teamId);
+    const result = await clockService.stop(userId);
     if (result === "not-found") return reply.status(404).send({ error: "No active clock event" });
     return { event: result };
   },
 
   async pause(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId } = req.body as { teamId: string };
-    const result = await clockService.pause(userId, teamId);
+    const result = await clockService.pause(userId);
     if (result === "not-found") return reply.status(404).send({ error: "No active clock event" });
     if (result === "already-paused")
       return reply.status(409).send({ error: "Clock is already paused" });
@@ -32,8 +29,7 @@ export const clockController = {
 
   async resume(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId } = req.body as { teamId: string };
-    const result = await clockService.resume(userId, teamId);
+    const result = await clockService.resume(userId);
     if (result === "not-found") return reply.status(404).send({ error: "No active clock event" });
     if (result === "not-paused") return reply.status(409).send({ error: "Clock is not paused" });
     return { event: result };
@@ -41,8 +37,7 @@ export const clockController = {
 
   async getStatus(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId } = req.query as { teamId: string };
-    const result = await clockService.getStatus(userId, teamId);
+    const result = await clockService.getStatus(userId);
     if (result === "not-found") return reply.status(404).send({ error: "No active clock event" });
     return result;
   },
@@ -74,12 +69,11 @@ export const clockController = {
 
   async createManual(req: FastifyRequest, reply: FastifyReply) {
     const userId = req.user!.id;
-    const { teamId, startTime, endTime } = req.body as {
-      teamId: string;
+    const { startTime, endTime } = req.body as {
       startTime: number;
       endTime: number;
     };
-    const result = await clockService.createManual(userId, teamId, startTime, endTime);
+    const result = await clockService.createManual(userId, startTime, endTime);
     if (result === "forbidden") return reply.status(403).send({ error: "Forbidden" });
     if (result === "invalid-range")
       return reply

--- a/backend/src/lib/ensure-indexes.ts
+++ b/backend/src/lib/ensure-indexes.ts
@@ -39,7 +39,7 @@ export async function ensureIndexes() {
 
   // ── Clock event indexes ─────────────────────────────────────────────────────
   const clockEvents = db.collection("clockevents");
-  await clockEvents.createIndex({ userId: 1, teamId: 1, endTime: 1 });
+  await clockEvents.createIndex({ userId: 1, endTime: 1 });
 
   // ── Clock break indexes ─────────────────────────────────────────────────────
   const clockBreaks = db.collection("clockbreaks");

--- a/backend/src/models/activity.model.ts
+++ b/backend/src/models/activity.model.ts
@@ -3,12 +3,12 @@ import type { ObjectId } from "mongodb";
 // ─── Payload types (one per activity type) ───────────────────────────────────
 
 export interface ClockInPayload {
-  teamId: string;
+  teamId?: string;
   teamName?: string;
 }
 
 export interface ClockOutPayload {
-  teamId: string;
+  teamId?: string;
   teamName?: string;
   durationSeconds?: number;
 }

--- a/backend/src/models/clock.model.ts
+++ b/backend/src/models/clock.model.ts
@@ -28,7 +28,7 @@ export interface ClockBreak extends ClockBreakInterval {
 export interface ClockEvent {
   _id: ObjectId;
   userId: string;
-  teamId: string;
+  teamId?: string;
   startTime: number; // epoch ms — shift start (mutable via updateTimes)
   accumulatedTime: number; // seconds — computed at clock-out (span minus deducted breaks)
   notifiedAt4h?: number | null; // epoch ms when 4h reminder was sent
@@ -37,26 +37,12 @@ export interface ClockEvent {
 
 // ─── ClockEvent helpers ────────────────────────────────────────────────────────
 
-export async function findActiveClockEventByUserTeam(
-  userId: string,
-  teamId: string
-): Promise<ClockEvent | null> {
-  return clockEventsCollection().findOne({ userId, teamId, endTime: null });
-}
-
 export async function findActiveClockEventByUser(userId: string): Promise<ClockEvent | null> {
   return clockEventsCollection().findOne({ userId, endTime: null });
 }
 
 export async function findClockEventsForUser(userId: string): Promise<ClockEvent[]> {
   return clockEventsCollection().find({ userId }).sort({ startTime: -1 }).toArray();
-}
-
-export async function findLiveClockEventsForTeams(teamIds: string[]): Promise<ClockEvent[]> {
-  if (!teamIds.length) return [];
-  return clockEventsCollection()
-    .find({ teamId: { $in: teamIds }, endTime: null })
-    .toArray();
 }
 
 // ─── ClockBreak helpers ────────────────────────────────────────────────────────

--- a/backend/src/routes/clock.ts
+++ b/backend/src/routes/clock.ts
@@ -1,10 +1,8 @@
 import { FastifyInstance } from "fastify";
-import { ObjectId } from "mongodb";
 import { auth } from "../lib/auth.js";
 import { requireAuth } from "../middleware/require-auth.js";
 import { clockService, toPublicClockEvent, subscribe } from "../services/clock.service.js";
 import { findBreaksForEvents } from "../models/clock.model.js";
-import { teamsCollection } from "../models/index.js";
 import { clockController } from "../controllers/clock.controller.js";
 
 // ─── Public shape schema ──────────────────────────────────────────────────────
@@ -14,7 +12,7 @@ const clockEventShape = {
   properties: {
     id: { type: "string" },
     userId: { type: "string" },
-    teamId: { type: "string" },
+    teamId: { type: "string", nullable: true },
     startTime: { type: "number" },
     accumulatedTime: { type: "number" },
     breaks: {
@@ -48,11 +46,6 @@ export async function clockRoutes(app: FastifyInstance) {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
-        body: {
-          type: "object",
-          required: ["teamId"],
-          properties: { teamId: { type: "string" } },
-        },
         response: { 200: { type: "object", properties: { event: clockEventShape } } },
       },
     },
@@ -66,13 +59,6 @@ export async function clockRoutes(app: FastifyInstance) {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
-        body: {
-          type: "object",
-          required: ["teamId"],
-          properties: {
-            teamId: { type: "string" },
-          },
-        },
         response: { 200: { type: "object", properties: { event: clockEventShape } } },
       },
     },
@@ -86,13 +72,6 @@ export async function clockRoutes(app: FastifyInstance) {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
-        body: {
-          type: "object",
-          required: ["teamId"],
-          properties: {
-            teamId: { type: "string" },
-          },
-        },
         response: { 200: { type: "object", properties: { event: clockEventShape } } },
       },
     },
@@ -106,33 +85,19 @@ export async function clockRoutes(app: FastifyInstance) {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
-        body: {
-          type: "object",
-          required: ["teamId"],
-          properties: {
-            teamId: { type: "string" },
-          },
-        },
         response: { 200: { type: "object", properties: { event: clockEventShape } } },
       },
     },
     clockController.resume
   );
 
-  // GET /v1/clock/status?teamId=...
+  // GET /v1/clock/status
   app.get(
     "/clock/status",
     {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
-        querystring: {
-          type: "object",
-          required: ["teamId"],
-          properties: {
-            teamId: { type: "string" },
-          },
-        },
       },
     },
     clockController.getStatus
@@ -196,9 +161,8 @@ export async function clockRoutes(app: FastifyInstance) {
         tags: ["Clock"],
         body: {
           type: "object",
-          required: ["teamId", "startTime", "endTime"],
+          required: ["startTime", "endTime"],
           properties: {
-            teamId: { type: "string" },
             startTime: { type: "number" },
             endTime: { type: "number" },
           },
@@ -258,11 +222,10 @@ export async function clockRoutes(app: FastifyInstance) {
     clockController.getEvents
   );
 
-  // GET /v1/clock/ws?teamIds=id1,id2 — WebSocket stream for live team clock state
+  // GET /v1/clock/ws — WebSocket stream for the authenticated user's live clock state
   app.get("/clock/ws", { websocket: true }, async (socket, req) => {
-    const { token: queryToken, teamIds: teamIdsParam } = req.query as {
+    const { token: queryToken } = req.query as {
       token?: string;
-      teamIds?: string;
     };
 
     // Auth: accept Bearer token from query param (Capacitor) or cookie
@@ -274,64 +237,21 @@ export async function clockRoutes(app: FastifyInstance) {
       return;
     }
 
-    if (!teamIdsParam) {
-      socket.close(4000, "teamIds required");
-      return;
-    }
-    const requestedIds = teamIdsParam
-      .split(",")
-      .map((s) => s.trim())
-      .filter(Boolean);
-
-    // Validate the requester is a member or admin of every requested team
-    const objectIds = requestedIds.flatMap((id) => {
-      try {
-        return [new ObjectId(id)];
-      } catch {
-        return [];
-      }
-    });
-    const allTeams = await teamsCollection()
-      .find({ _id: { $in: objectIds } })
-      .toArray();
-
     const userId = session.user.id;
-    const teamIds = allTeams
-      .filter((t) => {
-        const tid = t._id.toHexString();
-        return (
-          requestedIds.includes(tid) && (t.members?.includes(userId) || t.admins?.includes(userId))
-        );
-      })
-      .map((t) => t._id.toHexString());
-
-    if (teamIds.length === 0) {
-      socket.close(4003, "Forbidden");
-      return;
-    }
 
     // Send initial snapshot
-    const initial = await clockService.getLiveForTeams(teamIds);
-    const initialIds = initial.map((e) => e._id.toHexString());
-    const initialBreaks = await findBreaksForEvents(initialIds);
-    const initialBreaksByEventId = new Map<string, typeof initialBreaks>();
-    for (const b of initialBreaks) {
-      const arr = initialBreaksByEventId.get(b.clockEventId) ?? [];
-      arr.push(b);
-      initialBreaksByEventId.set(b.clockEventId, arr);
-    }
-    const snapshot = initial.map((e) =>
-      toPublicClockEvent(e, initialBreaksByEventId.get(e._id.toHexString()) ?? [])
-    );
+    const active = await clockService.getActiveForUser(userId);
+    const activeBreaks = active ? await findBreaksForEvents([active._id.toHexString()]) : [];
+    const snapshot = active ? [toPublicClockEvent(active, activeBreaks)] : [];
     if (socket.readyState === socket.OPEN) {
       socket.send(JSON.stringify({ type: "snapshot", events: snapshot }));
     }
 
     // Subscribe to future broadcasts
-    const unsub = subscribe((teamId, event) => {
-      if (!teamIds.includes(teamId)) return;
+    const unsub = subscribe((eventUserId, event) => {
+      if (eventUserId !== userId) return;
       if (socket.readyState === socket.OPEN) {
-        socket.send(JSON.stringify({ type: "update", teamId, event }));
+        socket.send(JSON.stringify({ type: "update", userId: eventUserId, event }));
       }
     });
 

--- a/backend/src/services/clock-monitor.service.ts
+++ b/backend/src/services/clock-monitor.service.ts
@@ -45,7 +45,6 @@ class ClockMonitorService {
             body: "Take a break. You have worked for 4 hours.",
             notificationData: {
               type: "break-reminder-4h",
-              teamId: event.teamId,
               clockEventId: event._id.toHexString(),
               url: "/app/clock",
             },

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -11,11 +11,9 @@ import {
 import type { ClockBreak, ClockBreakInterval, ClockEvent } from "../models/clock.model.js";
 import {
   findActiveClockEventByUser,
-  findActiveClockEventByUserTeam,
   findBreaksForEvent,
   findBreaksForEvents,
   findClockEventsForUser,
-  findLiveClockEventsForTeams,
 } from "../models/clock.model.js";
 import { timerService } from "./timer.service.js";
 import { ActivityType } from "../models/activity.model.js";
@@ -155,7 +153,7 @@ function normalizeBreakEntries(
 
 // ─── SSE broadcast ────────────────────────────────────────────────────────────
 
-type SseListener = (teamId: string, event: PublicClockEvent | null) => void;
+type SseListener = (userId: string, event: PublicClockEvent | null) => void;
 const sseListeners = new Set<SseListener>();
 
 export function subscribe(fn: SseListener): () => void {
@@ -163,8 +161,8 @@ export function subscribe(fn: SseListener): () => void {
   return () => sseListeners.delete(fn);
 }
 
-function broadcast(teamId: string, event: PublicClockEvent | null) {
-  for (const fn of sseListeners) fn(teamId, event);
+function broadcast(userId: string, event: PublicClockEvent | null) {
+  for (const fn of sseListeners) fn(userId, event);
 }
 
 // ─── Public shape ─────────────────────────────────────────────────────────────
@@ -207,7 +205,7 @@ export function toPublicClockEvent(e: ClockEvent, breaks: ClockBreakInterval[]) 
   return {
     id: e._id.toHexString(),
     userId: e.userId,
-    teamId: e.teamId,
+    ...(e.teamId ? { teamId: e.teamId } : {}),
     startTime,
     accumulatedTime: e.accumulatedTime,
     breaks: publicBreaks,
@@ -275,29 +273,16 @@ export class ClockService {
     return findClockEventsForUser(userId);
   }
 
-  /** Live clock events for a set of teams (used by SSE + dashboard). */
-  async getLiveForTeams(teamIds: string[]): Promise<ClockEvent[]> {
-    return findLiveClockEventsForTeams(teamIds);
-  }
-
-  async start(userId: string, teamId: string): Promise<PublicClockEvent | "forbidden"> {
-    if (!isValidId(teamId)) return "forbidden";
-    const team = await teamsCollection().findOne({
-      _id: new ObjectId(teamId),
-      $or: [{ members: userId }, { admins: userId }],
-    });
-    if (!team) return "forbidden";
-
+  async start(userId: string): Promise<PublicClockEvent | "forbidden"> {
     const coll = clockEventsCollection();
 
-    // Close any open events for this user+team
+    // Close any open events for this user before opening a fresh session.
     const now = Date.now();
-    await coll.updateMany({ userId, teamId, endTime: null }, { $set: { endTime: now } });
+    await coll.updateMany({ userId, endTime: null }, { $set: { endTime: now } });
 
     const result = await coll.insertOne({
       _id: new ObjectId(),
       userId,
-      teamId,
       startTime: now,
       accumulatedTime: 0,
       notifiedAt4h: null,
@@ -307,48 +292,40 @@ export class ClockService {
     const created = await coll.findOne({ _id: result.insertedId });
     if (!created) return "forbidden";
     const pub = toPublicClockEvent(created, []);
-    broadcast(teamId, pub);
+    broadcast(userId, pub);
 
-    // Notify team admins
+    // Notify the user (self) so they see immediate confirmation on all devices.
     const user = isValidId(userId)
       ? await usersCollection().findOne({ _id: new ObjectId(userId) })
       : null;
     const userName = user?.name ?? user?.email?.split("@")[0] ?? "Someone";
-    const notifyAdmins = (team.admins ?? []).filter((id) => id !== userId);
-    await Promise.all(
-      notifyAdmins.map((adminId) =>
-        notificationService
-          .create({
-            userId: adminId,
-            title: "TiméHuddle",
-            body: `${userName} clocked in to ${team.name}`,
-            notificationData: {
-              type: "clock-in",
-              userId,
-              userName,
-              teamName: team.name,
-              teamId,
-              url: `/app/clock`,
-            },
-          })
-          .catch(() => {})
-      )
-    );
+    await notificationService
+      .create({
+        userId,
+        title: "TiméHuddle",
+        body: `${userName} clocked in.`,
+        notificationData: {
+          type: "clock-in",
+          userId,
+          userName,
+          url: `/app/clock`,
+        },
+      })
+      .catch(() => {});
 
     void emitActivity({
       userId,
-      teamId,
       type: ActivityType.ClockIn,
       actor: { id: userId, name: userName },
-      payload: { teamId, teamName: team.name },
+      payload: {},
     });
 
     return pub;
   }
 
-  async stop(userId: string, teamId: string): Promise<PublicClockEvent | "not-found"> {
+  async stop(userId: string): Promise<PublicClockEvent | "not-found"> {
     const coll = clockEventsCollection();
-    const event = await coll.findOne({ userId, teamId, endTime: null });
+    const event = await coll.findOne({ userId, endTime: null });
     if (!event) return "not-found";
 
     const now = Date.now();
@@ -384,63 +361,46 @@ export class ClockService {
     const updated = await coll.findOne({ _id: event._id });
     if (!updated) return "not-found";
     const pub = toPublicClockEvent(updated, closedBreaks);
-    broadcast(teamId, null); // null = user is no longer clocked in
+    broadcast(userId, null); // null = user is no longer clocked in
 
-    // Notify team admins
-    const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
-    if (team) {
-      const user = isValidId(userId)
-        ? await usersCollection().findOne({ _id: new ObjectId(userId) })
-        : null;
-      const userName = user?.name ?? user?.email?.split("@")[0] ?? "Someone";
-      const totalSecs = pub.accumulatedTime ?? 0;
-      const h = Math.floor(totalSecs / 3600);
-      const m = Math.floor((totalSecs % 3600) / 60);
-      const durationText = h > 0 ? `${h}h ${m}m` : `${m}m`;
-      const notifyAdmins = (team.admins ?? []).filter((id) => id !== userId);
-      await Promise.all(
-        notifyAdmins.map((adminId) =>
-          notificationService
-            .create({
-              userId: adminId,
-              title: "TiméHuddle",
-              body: `${userName} clocked out of ${team.name} (${durationText})`,
-              notificationData: {
-                type: "clock-out",
-                userId,
-                userName,
-                teamName: team.name,
-                teamId,
-                duration: durationText,
-                url: `/app/clock`,
-              },
-            })
-            .catch(() => {})
-        )
-      );
-
-      void emitActivity({
+    const user = isValidId(userId)
+      ? await usersCollection().findOne({ _id: new ObjectId(userId) })
+      : null;
+    const userName = user?.name ?? user?.email?.split("@")[0] ?? "Someone";
+    const totalSecs = pub.accumulatedTime ?? 0;
+    const h = Math.floor(totalSecs / 3600);
+    const m = Math.floor((totalSecs % 3600) / 60);
+    const durationText = h > 0 ? `${h}h ${m}m` : `${m}m`;
+    await notificationService
+      .create({
         userId,
-        teamId,
-        type: ActivityType.ClockOut,
-        actor: { id: userId, name: userName },
-        payload: {
-          teamId,
-          teamName: team.name,
-          durationSeconds: pub.accumulatedTime ?? undefined,
+        title: "TiméHuddle",
+        body: `${userName} clocked out (${durationText}).`,
+        notificationData: {
+          type: "clock-out",
+          userId,
+          userName,
+          duration: durationText,
+          url: `/app/clock`,
         },
-      });
-    }
+      })
+      .catch(() => {});
+
+    void emitActivity({
+      userId,
+      type: ActivityType.ClockOut,
+      actor: { id: userId, name: userName },
+      payload: {
+        durationSeconds: pub.accumulatedTime ?? undefined,
+      },
+    });
 
     return pub;
   }
 
-  async pause(
-    userId: string,
-    teamId: string
-  ): Promise<PublicClockEvent | "not-found" | "already-paused"> {
+  async pause(userId: string): Promise<PublicClockEvent | "not-found" | "already-paused"> {
     const coll = clockEventsCollection();
-    const event = await coll.findOne({ userId, teamId, endTime: null });
+    const event = await coll.findOne({ userId, endTime: null });
     if (!event) return "not-found";
 
     const breaks = await findBreaksForEvent(event._id.toHexString());
@@ -461,16 +421,13 @@ export class ClockService {
     // Use optimistic in-memory view — avoid extra round-trip
     const updatedBreaks: ClockBreakInterval[] = [...breaks, { startTime: now, endTime: null }];
     const pub = toPublicClockEvent(event, updatedBreaks);
-    broadcast(teamId, pub);
+    broadcast(userId, pub);
     return pub;
   }
 
-  async resume(
-    userId: string,
-    teamId: string
-  ): Promise<PublicClockEvent | "not-found" | "not-paused"> {
+  async resume(userId: string): Promise<PublicClockEvent | "not-found" | "not-paused"> {
     const coll = clockEventsCollection();
-    const event = await coll.findOne({ userId, teamId, endTime: null });
+    const event = await coll.findOne({ userId, endTime: null });
     if (!event) return "not-found";
 
     const breaks = await findBreaksForEvent(event._id.toHexString());
@@ -490,14 +447,11 @@ export class ClockService {
       b._id.equals(openBreak._id) ? { ...b, endTime: now, ...classification } : b
     );
     const pub = toPublicClockEvent(event, updatedBreaks);
-    broadcast(teamId, pub);
+    broadcast(userId, pub);
     return pub;
   }
 
-  async getStatus(
-    userId: string,
-    teamId: string
-  ): Promise<
+  async getStatus(userId: string): Promise<
     | {
         event: PublicClockEvent;
         workSeconds: number;
@@ -505,7 +459,7 @@ export class ClockService {
       }
     | "not-found"
   > {
-    const event = await this.getActive(userId, teamId);
+    const event = await this.getActiveForUser(userId);
     if (!event) return "not-found";
 
     const now = Date.now();
@@ -540,6 +494,7 @@ export class ClockService {
 
     // Allow self-service edits for the event owner. Admins can also edit.
     if (event.userId !== requesterId) {
+      if (!event.teamId || !isValidId(event.teamId)) return "forbidden";
       const adminTeam = await teamsCollection().findOne({
         _id: new ObjectId(event.teamId),
         admins: requesterId,
@@ -619,6 +574,7 @@ export class ClockService {
     if (!event) return "not-found";
 
     if (event.userId !== requesterId) {
+      if (!event.teamId || !isValidId(event.teamId)) return "forbidden";
       const adminTeam = await teamsCollection().findOne({
         _id: new ObjectId(event.teamId),
         admins: requesterId,
@@ -635,7 +591,7 @@ export class ClockService {
     });
 
     if (event.endTime === null) {
-      broadcast(event.teamId, null);
+      broadcast(event.userId, null);
     }
 
     this.notifyClockAdmins(requesterId, event.teamId, event.startTime, "deleted").catch((err) =>
@@ -651,17 +607,9 @@ export class ClockService {
    */
   async createManual(
     userId: string,
-    teamId: string,
     startTime: number,
     endTime: number
   ): Promise<PublicClockEvent | "forbidden" | "invalid-range"> {
-    if (!isValidId(teamId)) return "forbidden";
-    const team = await teamsCollection().findOne({
-      _id: new ObjectId(teamId),
-      $or: [{ members: userId }, { admins: userId }],
-    });
-    if (!team) return "forbidden";
-
     const now = Date.now();
     if (startTime > now || endTime > now) return "invalid-range";
     if (endTime <= startTime) return "invalid-range";
@@ -671,7 +619,6 @@ export class ClockService {
     const result = await coll.insertOne({
       _id: new ObjectId(),
       userId,
-      teamId,
       startTime,
       accumulatedTime,
       endTime,

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -259,8 +259,8 @@ export class ClockService {
   }
 
   /** Return the active (open) clock event for a user in a team, or null. */
-  async getActive(userId: string, teamId: string): Promise<ClockEvent | null> {
-    return findActiveClockEventByUserTeam(userId, teamId);
+  async getActive(userId: string, _teamId: string): Promise<ClockEvent | null> {
+    return findActiveClockEventByUser(userId);
   }
 
   /** Return the active clock event across any team for the user. */
@@ -555,7 +555,7 @@ export class ClockService {
 
     const updated = await coll.findOne({ _id: event._id });
     const updatedBreaks = await findBreaksForEvent(clockEventId);
-    if (updated) {
+    if (updated && event.teamId) {
       this.notifyClockAdmins(requesterId, event.teamId, updated.startTime, "updated").catch((err) =>
         console.error("[clock.service] notify admins failed:", err)
       );
@@ -594,9 +594,11 @@ export class ClockService {
       broadcast(event.userId, null);
     }
 
-    this.notifyClockAdmins(requesterId, event.teamId, event.startTime, "deleted").catch((err) =>
-      console.error("[clock.service] notify admins failed:", err)
-    );
+    if (event.teamId) {
+      this.notifyClockAdmins(requesterId, event.teamId, event.startTime, "deleted").catch((err) =>
+        console.error("[clock.service] notify admins failed:", err)
+      );
+    }
 
     return "ok";
   }
@@ -608,7 +610,8 @@ export class ClockService {
   async createManual(
     userId: string,
     startTime: number,
-    endTime: number
+    endTime: number,
+    teamId?: string
   ): Promise<PublicClockEvent | "forbidden" | "invalid-range"> {
     const now = Date.now();
     if (startTime > now || endTime > now) return "invalid-range";
@@ -619,6 +622,7 @@ export class ClockService {
     const result = await coll.insertOne({
       _id: new ObjectId(),
       userId,
+      ...(teamId ? { teamId } : {}),
       startTime,
       accumulatedTime,
       endTime,
@@ -626,9 +630,11 @@ export class ClockService {
 
     const created = await coll.findOne({ _id: result.insertedId });
     if (!created) return "forbidden";
-    this.notifyClockAdmins(userId, teamId, startTime, "added").catch((err) =>
-      console.error("[clock.service] notify admins failed:", err)
-    );
+    if (teamId) {
+      this.notifyClockAdmins(userId, teamId, startTime, "added").catch((err) =>
+        console.error("[clock.service] notify admins failed:", err)
+      );
+    }
     return toPublicClockEvent(created, []);
   }
 

--- a/backend/tests/clock.test.ts
+++ b/backend/tests/clock.test.ts
@@ -28,7 +28,6 @@ let otherCookie: string;
 let workerId: string;
 let adminId: string;
 let otherId: string;
-let teamId: string;
 let clockEventId: string;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────

--- a/backend/tests/clock.test.ts
+++ b/backend/tests/clock.test.ts
@@ -27,6 +27,8 @@ let adminCookie: string;
 let otherCookie: string;
 let workerId: string;
 let adminId: string;
+let otherId: string;
+let teamId: string;
 let clockEventId: string;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -83,6 +85,7 @@ beforeAll(async () => {
 
   workerId = String((await db.collection("user").findOne({ email: WORKER.email }))!._id);
   adminId = String((await db.collection("user").findOne({ email: ADMIN.email }))!._id);
+  otherId = String((await db.collection("user").findOne({ email: OTHER.email }))!._id);
 
   // Create test team
   const teamDoc = {
@@ -104,7 +107,7 @@ beforeAll(async () => {
 afterAll(async () => {
   const db = client.db();
   await db.collection("teams").deleteOne({ code: "CLOCKTEAM1" });
-  await db.collection("clockevents").deleteMany({ userId: workerId });
+  await db.collection("clockevents").deleteMany({ userId: { $in: [workerId, adminId, otherId] } });
   await db.collection("notifications").deleteMany({ userId: workerId });
   await db.collection("timers").deleteMany({ userId: workerId });
   await db.collection("workitems").deleteMany({ userId: workerId });

--- a/backend/tests/clock.test.ts
+++ b/backend/tests/clock.test.ts
@@ -27,7 +27,6 @@ let adminCookie: string;
 let otherCookie: string;
 let workerId: string;
 let adminId: string;
-let teamId: string;
 let clockEventId: string;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
@@ -96,7 +95,6 @@ beforeAll(async () => {
     createdAt: new Date(),
   };
   await db.collection("teams").insertOne(teamDoc);
-  teamId = teamDoc._id.toHexString();
 
   workerCookie = await getSessionCookie(WORKER.email, WORKER.password);
   adminCookie = await getSessionCookie(ADMIN.email, ADMIN.password);
@@ -106,7 +104,7 @@ beforeAll(async () => {
 afterAll(async () => {
   const db = client.db();
   await db.collection("teams").deleteOne({ code: "CLOCKTEAM1" });
-  await db.collection("clockevents").deleteMany({ teamId });
+  await db.collection("clockevents").deleteMany({ userId: workerId });
   await db.collection("notifications").deleteMany({ userId: workerId });
   await db.collection("timers").deleteMany({ userId: workerId });
   await db.collection("workitems").deleteMany({ userId: workerId });
@@ -121,7 +119,7 @@ describe("auth gate", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/clock/start",
-      payload: { teamId: "abc" },
+      payload: {},
     });
     expect(res.statusCode).toBe(401);
   });
@@ -130,7 +128,7 @@ describe("auth gate", () => {
     const res = await app.inject({
       method: "POST",
       url: "/v1/clock/stop",
-      payload: { teamId: "abc" },
+      payload: {},
     });
     expect(res.statusCode).toBe(401);
   });
@@ -140,27 +138,27 @@ describe("auth gate", () => {
 
 describe("POST /v1/clock/start", () => {
   it("clocks in — 200, returns event", async () => {
-    const res = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const res = await inject("POST", "/v1/clock/start", workerCookie);
     expect(res.statusCode).toBe(200);
     const { event } = res.json();
     expect(event.userId).toBe(workerId);
-    expect(event.teamId).toBe(teamId);
     expect(event.endTime).toBeNull();
     expect(typeof event.startTime).toBe("number");
     clockEventId = event.id;
   });
 
   it("clocking in again closes the previous event and opens a new one", async () => {
-    const res = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const res = await inject("POST", "/v1/clock/start", workerCookie);
     expect(res.statusCode).toBe(200);
     const { event } = res.json();
     expect(event.id).not.toBe(clockEventId);
     clockEventId = event.id; // use the latest one
   });
 
-  it("returns 403 when user is not a team member", async () => {
-    const res = await inject("POST", "/v1/clock/start", otherCookie, { teamId });
-    expect(res.statusCode).toBe(403);
+  it("allows any authenticated user to clock in", async () => {
+    const res = await inject("POST", "/v1/clock/start", otherCookie);
+    expect(res.statusCode).toBe(200);
+    await inject("POST", "/v1/clock/stop", otherCookie);
   });
 });
 
@@ -186,53 +184,45 @@ describe("GET /v1/clock/active", () => {
 
 describe("clock break flow", () => {
   it("pauses and resumes an active clock event", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
 
-    const pauseRes = await inject("POST", "/v1/clock/pause", workerCookie, { teamId });
+    const pauseRes = await inject("POST", "/v1/clock/pause", workerCookie);
     expect(pauseRes.statusCode).toBe(200);
     expect(pauseRes.json().event.isPaused).toBe(true);
     expect(Array.isArray(pauseRes.json().event.breaks)).toBe(true);
     expect(pauseRes.json().event.breaks.length).toBeGreaterThan(0);
     expect(pauseRes.json().event.breaks[0].endTime).toBeNull();
 
-    const statusWhilePaused = await inject(
-      "GET",
-      `/v1/clock/status?teamId=${teamId}`,
-      workerCookie
-    );
+    const statusWhilePaused = await inject("GET", "/v1/clock/status", workerCookie);
     expect(statusWhilePaused.statusCode).toBe(200);
     expect(statusWhilePaused.json().isPaused).toBe(true);
 
-    const resumeRes = await inject("POST", "/v1/clock/resume", workerCookie, { teamId });
+    const resumeRes = await inject("POST", "/v1/clock/resume", workerCookie);
     expect(resumeRes.statusCode).toBe(200);
     expect(resumeRes.json().event.isPaused).toBe(false);
     expect(Array.isArray(resumeRes.json().event.breaks)).toBe(true);
     expect(resumeRes.json().event.breaks[0].endTime).not.toBeNull();
 
-    const statusAfterResume = await inject(
-      "GET",
-      `/v1/clock/status?teamId=${teamId}`,
-      workerCookie
-    );
+    const statusAfterResume = await inject("GET", "/v1/clock/status", workerCookie);
     expect(statusAfterResume.statusCode).toBe(200);
     expect(statusAfterResume.json().isPaused).toBe(false);
 
-    const stopRes = await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    const stopRes = await inject("POST", "/v1/clock/stop", workerCookie);
     expect(stopRes.statusCode).toBe(200);
   });
 
   it("returns 409 when pausing an already paused clock", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
 
-    const firstPause = await inject("POST", "/v1/clock/pause", workerCookie, { teamId });
+    const firstPause = await inject("POST", "/v1/clock/pause", workerCookie);
     expect(firstPause.statusCode).toBe(200);
 
-    const secondPause = await inject("POST", "/v1/clock/pause", workerCookie, { teamId });
+    const secondPause = await inject("POST", "/v1/clock/pause", workerCookie);
     expect(secondPause.statusCode).toBe(409);
 
-    await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    await inject("POST", "/v1/clock/stop", workerCookie);
   });
 });
 
@@ -243,7 +233,7 @@ describe("clock monitor enforcement", () => {
     const db = client.db();
     await db.collection("notifications").deleteMany({ userId: workerId });
 
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const eventId = startRes.json().event.id as string;
 
@@ -270,7 +260,7 @@ describe("clock monitor enforcement", () => {
       .toArray();
     expect(reminders.length).toBe(1);
 
-    await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    await inject("POST", "/v1/clock/stop", workerCookie);
   });
 });
 
@@ -305,10 +295,10 @@ describe("POST /v1/attachments (clock)", () => {
 
 describe("POST /v1/clock/stop", () => {
   it("clocks out — 200, sets endTime", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
 
-    const res = await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    const res = await inject("POST", "/v1/clock/stop", workerCookie);
     expect(res.statusCode).toBe(200);
     const { event } = res.json();
     expect(event.endTime).not.toBeNull();
@@ -322,7 +312,7 @@ describe("POST /v1/clock/stop", () => {
   });
 
   it("returns 404 when already clocked out", async () => {
-    const res = await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    const res = await inject("POST", "/v1/clock/stop", workerCookie);
     expect(res.statusCode).toBe(404);
   });
 });
@@ -343,13 +333,12 @@ describe("GET /v1/clock/events", () => {
 // ─── PUT /v1/clock/:id/times ─────────────────────────────────────────────────
 
 describe("PUT /v1/clock/:id/times", () => {
-  it("admin can adjust start time — 200", async () => {
+  it("non-owner cannot adjust teamless event — 403", async () => {
     const newStart = Date.now() - 3600_000; // 1 hour ago
     const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
       startTime: newStart,
     });
-    expect(res.statusCode).toBe(200);
-    expect(res.json().event.startTime).toBe(newStart);
+    expect(res.statusCode).toBe(403);
   });
 
   it("event owner can adjust times — 200", async () => {
@@ -370,7 +359,7 @@ describe("PUT /v1/clock/:id/times", () => {
 
   it("returns 422 if endTime < startTime", async () => {
     const now = Date.now();
-    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       startTime: now,
       endTime: now - 1000,
     });
@@ -380,12 +369,12 @@ describe("PUT /v1/clock/:id/times", () => {
   it("returns 422 when only startTime is moved past existing endTime", async () => {
     // First set a known startTime + endTime pair
     const base = Date.now() - 3600_000;
-    await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       startTime: base,
       endTime: base + 1000,
     });
     // Now move startTime past the stored endTime
-    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       startTime: base + 5000,
     });
     expect(res.statusCode).toBe(422);
@@ -394,19 +383,19 @@ describe("PUT /v1/clock/:id/times", () => {
   it("returns 422 when only endTime is set before existing startTime", async () => {
     // First set a known startTime
     const base = Date.now() - 3600_000;
-    await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       startTime: base,
       endTime: base + 10_000,
     });
     // Now move endTime before the stored startTime
-    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       endTime: base - 1000,
     });
     expect(res.statusCode).toBe(422);
   });
 
   it("shrinks overlapping break periods and recalculates totals on edit", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const eventId = startRes.json().event.id as string;
 
@@ -450,7 +439,7 @@ describe("PUT /v1/clock/:id/times", () => {
   });
 
   it("accepts manual break edits and recalculates session totals", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const eventId = startRes.json().event.id as string;
 
@@ -476,7 +465,7 @@ describe("PUT /v1/clock/:id/times", () => {
   });
 
   it("clearing endTime (null) always succeeds regardless of startTime", async () => {
-    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, adminCookie, {
+    const res = await inject("PUT", `/v1/clock/${clockEventId}/times`, workerCookie, {
       endTime: null,
     });
     expect(res.statusCode).toBe(200);
@@ -488,7 +477,7 @@ describe("PUT /v1/clock/:id/times", () => {
 
 describe("DELETE /v1/clock/:id", () => {
   it("event owner can delete a clock event — 200", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const ownedEventId = startRes.json().event.id as string;
 
@@ -497,18 +486,19 @@ describe("DELETE /v1/clock/:id", () => {
     expect(deleteRes.json().ok).toBe(true);
   });
 
-  it("team admin can delete another member's clock event — 200", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+  it("non-owner cannot delete a teamless event — 403", async () => {
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const targetEventId = startRes.json().event.id as string;
 
     const deleteRes = await inject("DELETE", `/v1/clock/${targetEventId}`, adminCookie);
-    expect(deleteRes.statusCode).toBe(200);
-    expect(deleteRes.json().ok).toBe(true);
+    expect(deleteRes.statusCode).toBe(403);
+
+    await inject("DELETE", `/v1/clock/${targetEventId}`, workerCookie);
   });
 
   it("non-owner non-admin returns 403", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const targetEventId = startRes.json().event.id as string;
 
@@ -548,7 +538,7 @@ describe("GET /v1/clock/timesheet", () => {
   });
 
   it("includes live elapsed time for an active session in summary totals", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const activeEventId = startRes.json().event.id as string;
 
@@ -575,11 +565,11 @@ describe("GET /v1/clock/timesheet", () => {
     const minLiveSeconds = Math.max(0, Math.floor((Date.now() - twoMinutesAgo) / 1000) - 2);
     expect(res.json().summary.totalSeconds).toBeGreaterThanOrEqual(minLiveSeconds);
 
-    await inject("POST", "/v1/clock/stop", workerCookie, { teamId });
+    await inject("POST", "/v1/clock/stop", workerCookie);
   });
 
   it("includes a completed session that spans a midnight boundary", async () => {
-    const startRes = await inject("POST", "/v1/clock/start", workerCookie, { teamId });
+    const startRes = await inject("POST", "/v1/clock/start", workerCookie);
     expect(startRes.statusCode).toBe(200);
     const crossMidnightEventId = startRes.json().event.id as string;
 

--- a/backend/tests/timers.test.ts
+++ b/backend/tests/timers.test.ts
@@ -698,7 +698,7 @@ describe("clock-out closes all open timer sessions", () => {
     const db = client.db();
 
     // Clock in to the team
-    await inject("POST", "/v1/clock/start", cookieA, { teamId });
+    await inject("POST", "/v1/clock/start", cookieA);
 
     // Start a timer session for the ticket
     const today = new Date().toISOString().slice(0, 10);
@@ -711,7 +711,7 @@ describe("clock-out closes all open timer sessions", () => {
     expect(runningBefore).not.toBeNull();
 
     // Clock out — this should close all timers
-    await inject("POST", "/v1/clock/stop", cookieA, { teamId });
+    await inject("POST", "/v1/clock/stop", cookieA);
 
     // Verify no timers are running for this user
     const runningAfter = await db.collection("timers").findOne({ userId: userAId, endTime: null });
@@ -723,13 +723,13 @@ describe("clock-out closes all open timer sessions", () => {
 
 describe("ClockEvent no longer has tickets[]", () => {
   it("POST /v1/clock/start returns event without tickets field", async () => {
-    const res = await inject("POST", "/v1/clock/start", cookieA, { teamId });
+    const res = await inject("POST", "/v1/clock/start", cookieA);
     expect(res.statusCode).toBe(200);
     const { event } = res.json();
     expect(event.tickets).toBeUndefined();
 
     // Clock back out
-    await inject("POST", "/v1/clock/stop", cookieA, { teamId });
+    await inject("POST", "/v1/clock/stop", cookieA);
   });
 });
 

--- a/e2e/clock-breaks.spec.ts
+++ b/e2e/clock-breaks.spec.ts
@@ -37,26 +37,16 @@ async function login(page: import('@playwright/test').Page) {
 /** Stop any active clock session so each test starts clean. */
 async function ensureClockedOut(page: import('@playwright/test').Page) {
   const res = await page.request.get(`${API_BASE}/clock/active`);
-  const { event } = (await res.json()) as { event: { teamId: string } | null };
+  const { event } = (await res.json()) as { event: { id: string } | null };
   if (!event) return;
-  await page.request.post(`${API_BASE}/clock/stop`, {
-    data: { teamId: event.teamId },
-  });
+  await page.request.post(`${API_BASE}/clock/stop`, {});
 }
 
-/** Fetch alice's first team and clock in. Returns the new event id. */
-async function clockIn(
-  page: import('@playwright/test').Page,
-): Promise<{ eventId: string; teamId: string }> {
-  const teamsRes = await page.request.get(`${API_BASE}/teams`);
-  const { teams } = (await teamsRes.json()) as { teams: { id: string }[] };
-  const teamId = teams[0].id;
-
-  const startRes = await page.request.post(`${API_BASE}/clock/start`, {
-    data: { teamId },
-  });
+/** Clock in and return the new event id. */
+async function clockIn(page: import('@playwright/test').Page): Promise<{ eventId: string }> {
+  const startRes = await page.request.post(`${API_BASE}/clock/start`, {});
   const { event } = (await startRes.json()) as { event: { id: string } };
-  return { eventId: event.id, teamId };
+  return { eventId: event.id };
 }
 
 type ClockBreakShape = {
@@ -112,12 +102,10 @@ test.describe('Clock Break Classification', () => {
   // ── Test 1: Live pause → resume ───────────────────────────────────────────
 
   test('live pause/resume auto-classifies short break as rest', async ({ page }) => {
-    const { teamId } = await clockIn(page);
+    await clockIn(page);
 
     // Pause
-    const pauseRes = await page.request.post(`${API_BASE}/clock/pause`, {
-      data: { teamId },
-    });
+    const pauseRes = await page.request.post(`${API_BASE}/clock/pause`, {});
     const { event: paused } = (await pauseRes.json()) as { event: PublicClockEvent };
     expect(paused.isPaused).toBe(true);
 
@@ -125,9 +113,7 @@ test.describe('Clock Break Classification', () => {
     await page.waitForTimeout(1100);
 
     // Resume
-    const resumeRes = await page.request.post(`${API_BASE}/clock/resume`, {
-      data: { teamId },
-    });
+    const resumeRes = await page.request.post(`${API_BASE}/clock/resume`, {});
     const { event: resumed } = (await resumeRes.json()) as { event: PublicClockEvent };
 
     expect(resumed.isPaused).toBe(false);

--- a/e2e/work.spec.ts
+++ b/e2e/work.spec.ts
@@ -16,12 +16,10 @@ async function ensureClockedOut(page: import('@playwright/test').Page) {
   // page.request shares the browser's cookie jar. The backend is at port 4000;
   // localhost cookies are shared across ports so the auth session is included.
   const activeRes = await page.request.get('http://localhost:4000/v1/clock/active');
-  const { event } = (await activeRes.json()) as { event: { teamId: string } | null };
+  const { event } = (await activeRes.json()) as { event: { id: string } | null };
   if (!event) return;
 
-  await page.request.post('http://localhost:4000/v1/clock/stop', {
-    data: { teamId: event.teamId },
-  });
+  await page.request.post('http://localhost:4000/v1/clock/stop', {});
 }
 
 async function ensureNoRunningTimer(page: import('@playwright/test').Page) {

--- a/src/features/clock/ClockPage.tsx
+++ b/src/features/clock/ClockPage.tsx
@@ -15,7 +15,7 @@ import { useRouter } from '../../ui/router';
 // ─── ClockPage ────────────────────────────────────────────────────────────────
 
 export const ClockPage: React.FC = () => {
-  const { selectedTeamId, activeClockEvent, currentTime, teamsReady } = useTeam();
+  const { activeClockEvent, currentTime, teamsReady } = useTeam();
   const { navigate } = useRouter();
 
   const {
@@ -86,7 +86,6 @@ export const ClockPage: React.FC = () => {
                 <Button
                   onClick={clockIn}
                   isLoading={clockInLoading}
-                  disabled={!selectedTeamId}
                   className="flex w-full items-center justify-center gap-3 rounded-2xl bg-green-500 py-4 text-white shadow-lg transition-transform hover:scale-[1.02] hover:bg-green-600 active:scale-95 disabled:opacity-50 sm:h-16 sm:w-16 sm:rounded-full sm:py-0"
                   aria-label="Clock in"
                 >

--- a/src/features/clock/TimesheetPage.tsx
+++ b/src/features/clock/TimesheetPage.tsx
@@ -21,7 +21,6 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
-  Select,
   Spinner,
   Table,
   TableBody,
@@ -112,7 +111,6 @@ export const TimesheetPage: React.FC = () => {
   const [addEntryOpen, setAddEntryOpen] = useState(false);
   const [newClockIn, setNewClockIn] = useState('');
   const [newClockOut, setNewClockOut] = useState('');
-  const [newTeamId, setNewTeamId] = useState('');
   const [addEntryLoading, setAddEntryLoading] = useState(false);
   const [addEntryError, setAddEntryError] = useState<string | null>(null);
 
@@ -293,10 +291,9 @@ export const TimesheetPage: React.FC = () => {
   const openAddEntry = useCallback(() => {
     setNewClockIn('');
     setNewClockOut('');
-    setNewTeamId(selectedTeamId ?? teams[0]?.id ?? '');
     setAddEntryError(null);
     setAddEntryOpen(true);
-  }, [selectedTeamId, teams]);
+  }, []);
 
   const handleAddEntry = useCallback(async () => {
     const parsedStart = fromLocalDateTimeInputValue(newClockIn);
@@ -318,22 +315,16 @@ export const TimesheetPage: React.FC = () => {
       setAddEntryError('Clock-out must be after clock-in.');
       return;
     }
-    if (!newTeamId) {
-      setAddEntryError('Please select a team.');
-      return;
-    }
     setAddEntryLoading(true);
     setAddEntryError(null);
     try {
       await clockApi.createManualEntry({
-        teamId: newTeamId,
         startTime: parsedStart,
         endTime: parsedEnd,
       });
       setAddEntryOpen(false);
       setNewClockIn('');
       setNewClockOut('');
-      setNewTeamId('');
       await fetchData();
     } catch (e) {
       if (e instanceof ApiError) {
@@ -344,7 +335,7 @@ export const TimesheetPage: React.FC = () => {
     } finally {
       setAddEntryLoading(false);
     }
-  }, [newClockIn, newClockOut, newTeamId, fetchData]);
+  }, [newClockIn, newClockOut, fetchData]);
 
   // Duration previews (display-only, computed from inputs)
   const editDurationSeconds = useMemo(() => {
@@ -379,19 +370,13 @@ export const TimesheetPage: React.FC = () => {
     return teams.find((t) => t.id === activeSession.teamId)?.name ?? '';
   }, [activeSession, teams]);
 
-  // Team options for new entry (exclude personal workspace)
-  const teamOptions = useMemo(
-    () => teams.filter((t) => !t.isPersonal).map((t) => ({ value: t.id, label: t.name })),
-    [teams],
-  );
-
   const presets = PRESETS;
 
-  // Filter sessions by selected team
+  // Filter sessions by selected team. Teamless sessions remain visible.
   const filteredSessions = useMemo(() => {
     if (!data) return [];
     return selectedTeamId
-      ? data.sessions.filter((s) => s.teamId === selectedTeamId)
+      ? data.sessions.filter((s) => !s.teamId || s.teamId === selectedTeamId)
       : data.sessions;
   }, [data, selectedTeamId]);
 
@@ -450,7 +435,6 @@ export const TimesheetPage: React.FC = () => {
           size="sm"
           leftIcon={<FontAwesomeIcon icon={faPlus} />}
           onClick={openAddEntry}
-          disabled={teamOptions.length === 0}
         >
           Add Entry
         </Button>
@@ -571,14 +555,13 @@ export const TimesheetPage: React.FC = () => {
                   <TableHead>Clock In</TableHead>
                   <TableHead>Clock Out</TableHead>
                   <TableHead>Duration</TableHead>
-                  <TableHead>Team</TableHead>
                   <TableHead>Status</TableHead>
                   <TableHead className="w-16 text-right">Actions</TableHead>
                 </TableRow>
               </TableHeader>
               <TableBody>
                 {filteredSessions.map((s) => (
-                  <TimesheetRow key={s.id} session={s} teams={teams} onEdit={openSessionDialog} />
+                  <TimesheetRow key={s.id} session={s} onEdit={openSessionDialog} />
                 ))}
               </TableBody>
             </Table>
@@ -772,12 +755,6 @@ export const TimesheetPage: React.FC = () => {
           </Text>
         </ModalHeader>
         <ModalBody className="space-y-4">
-          <Select
-            label="Team"
-            value={newTeamId}
-            onValueChange={(val) => setNewTeamId(val)}
-            options={teamOptions}
-          />
           <Input
             label="Clock In"
             type="datetime-local"

--- a/src/features/clock/TimesheetRow.test.tsx
+++ b/src/features/clock/TimesheetRow.test.tsx
@@ -76,11 +76,7 @@ describe('TimesheetRow', () => {
     render(
       <table>
         <tbody>
-          <TimesheetRow
-            session={session}
-            teams={[{ id: 'team-1', name: 'Mobile test' }]}
-            onEdit={vi.fn()}
-          />
+          <TimesheetRow session={session} onEdit={vi.fn()} />
         </tbody>
       </table>,
     );
@@ -100,11 +96,7 @@ describe('TimesheetRow', () => {
     render(
       <table>
         <tbody>
-          <TimesheetRow
-            session={session}
-            teams={[{ id: 'team-1', name: 'Mobile test' }]}
-            onEdit={onEdit}
-          />
+          <TimesheetRow session={session} onEdit={onEdit} />
         </tbody>
       </table>,
     );
@@ -122,11 +114,7 @@ describe('TimesheetRow', () => {
     render(
       <table>
         <tbody>
-          <TimesheetRow
-            session={session}
-            teams={[{ id: 'team-1', name: 'Night Crew' }]}
-            onEdit={vi.fn()}
-          />
+          <TimesheetRow session={session} onEdit={vi.fn()} />
         </tbody>
       </table>,
     );
@@ -141,8 +129,8 @@ describe('TimesheetRow', () => {
     // "Completed" status only on the newest row (May 21); May 20 is isContinued so no status
     expect(screen.getAllByText('Completed')).toHaveLength(1);
 
-    // Team name on the oldest row (May 20, the original clock-in day)
-    expect(screen.getByText('Night Crew')).toBeTruthy();
+    // Team column was removed from the table; no team label is rendered.
+    expect(screen.queryByText('Night Crew')).toBeNull();
   });
 
   it('shows the edit action on the newest row for a cross-midnight session', () => {
@@ -152,11 +140,7 @@ describe('TimesheetRow', () => {
     render(
       <table>
         <tbody>
-          <TimesheetRow
-            session={session}
-            teams={[{ id: 'team-1', name: 'Night Crew' }]}
-            onEdit={onEdit}
-          />
+          <TimesheetRow session={session} onEdit={onEdit} />
         </tbody>
       </table>,
     );

--- a/src/features/clock/TimesheetRow.tsx
+++ b/src/features/clock/TimesheetRow.tsx
@@ -16,14 +16,8 @@ import { type ClockEvent } from '../../lib/api';
 
 // ─── Types ────────────────────────────────────────────────────────────────────
 
-interface Team {
-  id: string;
-  name: string;
-}
-
 interface Props {
   session: ClockEvent;
-  teams: Team[];
   onEdit: (session: ClockEvent) => void;
 }
 
@@ -180,16 +174,13 @@ function splitAtMidnight(rows: TimelineRow[]): TimelineRow[] {
 
 // ─── Component ────────────────────────────────────────────────────────────────
 
-export const TimesheetRow: React.FC<Props> = ({ session, teams, onEdit }) => {
-  const teamName = teams.find((t) => t.id === session.teamId)?.name ?? session.teamId;
+export const TimesheetRow: React.FC<Props> = ({ session, onEdit }) => {
   const timelineRows = splitAtMidnight(buildTimelineRows(session, Date.now()));
 
   return (
     <>
       {timelineRows.map((row, idx) => {
         const showActions = idx === 0;
-        // Team name belongs on the chronologically-first segment (last in desc-sorted array)
-        const showTeam = idx === timelineRows.length - 1;
         return (
           <TableRow key={`${session.id}-${row.kind}-${idx}`}>
             <TableCell>{formatDate(new Date(row.start), true)}</TableCell>
@@ -218,7 +209,6 @@ export const TimesheetRow: React.FC<Props> = ({ session, teams, onEdit }) => {
             <TableCell className="font-mono">
               {row.durationSeconds !== null ? formatDuration(row.durationSeconds) : '—'}
             </TableCell>
-            <TableCell>{showTeam ? teamName : ''}</TableCell>
             <TableCell>
               {row.isContinued ? null : row.status === 'Active' ? (
                 <Badge variant="success" size="sm">

--- a/src/features/clock/schema.ts
+++ b/src/features/clock/schema.ts
@@ -3,11 +3,11 @@ import { z } from 'zod';
 // ─── Schemas ──────────────────────────────────────────────────────────────────
 
 export const clockEventStartSchema = z.object({
-  teamId: z.string().min(1),
+  teamId: z.string().min(1).optional(),
 });
 
 export const clockEventStopSchema = z.object({
-  teamId: z.string().min(1),
+  teamId: z.string().min(1).optional(),
   youtubeShortLink: z.string().optional(),
 });
 
@@ -38,7 +38,7 @@ export type TimesheetQueryInput = z.infer<typeof timesheetQuerySchema>;
 export interface ClockEventDoc {
   _id?: string;
   userId: string;
-  teamId: string;
+  teamId?: string;
   startTime: number;
   accumulatedTime: number;
   endTime: number | null;
@@ -48,7 +48,7 @@ export interface ClockEventDoc {
 export interface SessionDoc {
   _id?: string;
   userId: string;
-  teamId: string;
+  teamId?: string;
   startTime: Date;
   endTime?: Date;
   duration?: number;

--- a/src/features/teams/AdminDayGroup.tsx
+++ b/src/features/teams/AdminDayGroup.tsx
@@ -129,7 +129,7 @@ export const AdminDayGroup: React.FC<Props> = ({
       {/* ── Expanded session rows ── */}
       {isExpanded &&
         sortedSessions.map((session) => (
-          <TimesheetRow key={session.id} session={session} teams={teams} onEdit={onEdit} />
+          <TimesheetRow key={session.id} session={session} onEdit={onEdit} />
         ))}
     </>
   );

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -106,7 +106,7 @@ function entryTotalSeconds(sessions: Timer[], now: number): number {
 // ─── WorkPage ─────────────────────────────────────────────────────────────────
 
 export const WorkPage: React.FC = () => {
-  const { teams, teamsReady, currentTime, selectedTeamId, activeClockEvent } = useTeam();
+  const { teams, teamsReady, currentTime, activeClockEvent } = useTeam();
   const { isClockedIn, clockIn, clockInLoading } = useClockToggle();
   const previousClockedInRef = useRef(isClockedIn);
   // When clock-in is immediately followed by startTimerForEntry, suppress the
@@ -267,10 +267,7 @@ export const WorkPage: React.FC = () => {
   // ── Real-time clock updates ──
 
   useEffect(() => {
-    if (teams.length === 0) return;
-
-    const teamIds = teams.map((t) => t.id);
-    const ws = clockApi.openLiveStream(teamIds);
+    const ws = clockApi.openLiveStream();
 
     ws.onmessage = (event: MessageEvent) => {
       const data = JSON.parse(event.data);
@@ -282,7 +279,7 @@ export const WorkPage: React.FC = () => {
     };
 
     return () => ws.close();
-  }, [teams, fetchDay, fetchWeekTotals]);
+  }, [fetchDay, fetchWeekTotals]);
 
   // ── Real-time timer updates ──
 
@@ -363,11 +360,6 @@ export const WorkPage: React.FC = () => {
   const handleClockInAndStart = useCallback(async () => {
     if (!pendingStartEntryId) return;
 
-    if (!selectedTeamId) {
-      setClockInPromptError('Select a team before clocking in.');
-      return;
-    }
-
     setClockInPromptError(null);
     skipNextClockInFetchRef.current = true;
     await clockIn();
@@ -377,7 +369,7 @@ export const WorkPage: React.FC = () => {
     setPendingStartEntryId(null);
 
     await startTimerForEntry(entryId);
-  }, [pendingStartEntryId, selectedTeamId, clockIn, startTimerForEntry]);
+  }, [pendingStartEntryId, clockIn, startTimerForEntry]);
 
   const handleStop = useCallback(
     async (sessionId: string) => {

--- a/src/lib/TeamContext.tsx
+++ b/src/lib/TeamContext.tsx
@@ -197,37 +197,31 @@ export const TeamProvider: React.FC<{ children: React.ReactNode }> = ({ children
 
   // Real-time WebSocket connection for clock updates
   useEffect(() => {
-    if (!userId || !selectedTeamId) {
+    if (!userId) {
       return;
     }
 
-    const ws = clockApi.openLiveStream([selectedTeamId]);
+    const ws = clockApi.openLiveStream();
 
     ws.onmessage = (event: MessageEvent) => {
       try {
         const data = JSON.parse(event.data);
 
         if (data.type === 'snapshot') {
-          // Initial snapshot: find the current user's active event from the array
+          // Initial snapshot: find the current user's active event from the array.
           const userEvent =
-            data.events?.find(
-              (e: ClockEvent) => e.userId === userId && e.teamId === selectedTeamId && !e.endTime,
-            ) ?? null;
+            data.events?.find((e: ClockEvent) => e.userId === userId && !e.endTime) ?? null;
           setActiveClockEvent(userEvent);
           setClockReady(true);
         } else if (data.type === 'update') {
           // Real-time update: apply if it's for the current user
           const updatedEvent = data.event as ClockEvent | null;
-          if (
-            updatedEvent &&
-            updatedEvent.userId === userId &&
-            updatedEvent.teamId === selectedTeamId
-          ) {
+          if (updatedEvent && updatedEvent.userId === userId) {
             setActiveClockEvent(updatedEvent);
           } else if (!updatedEvent) {
-            // Clock out (event is null) — clear active event if it was for this user/team
+            // Clock out (event is null) — clear active event for this user.
             setActiveClockEvent((prev) => {
-              if (prev && prev.teamId === data.teamId) {
+              if (prev && data.userId === userId) {
                 return null;
               }
               return prev;
@@ -240,11 +234,11 @@ export const TeamProvider: React.FC<{ children: React.ReactNode }> = ({ children
       }
     };
 
-    // Cleanup: close WebSocket connection when team changes or component unmounts
+    // Cleanup: close WebSocket connection when user changes or component unmounts
     return () => {
       ws.close();
     };
-  }, [userId, selectedTeamId, refetchClock]);
+  }, [userId]);
 
   // ── Live timer ──────────────────────────────────────────────────────────────
 

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -665,7 +665,7 @@ export const teamApi = {
 export interface ClockEvent {
   id: string;
   userId: string;
-  teamId: string;
+  teamId?: string;
   startTime: number;
   /** @deprecated No longer returned by the API — use startTime. */
   originalStartTime?: number;
@@ -687,41 +687,37 @@ export interface ClockEvent {
 }
 
 export const clockApi = {
-  /** Clock in to a team. Returns the new clock event. */
-  start: (teamId: string) =>
+  /** Clock in. Returns the new clock event. */
+  start: () =>
     request<{ event: ClockEvent }>('/v1/clock/start', {
       method: 'POST',
-      body: JSON.stringify({ teamId }),
     }).then((r) => r.event),
 
-  /** Clock out of a team. */
-  stop: (teamId: string) =>
+  /** Clock out. */
+  stop: () =>
     request<{ event: ClockEvent }>('/v1/clock/stop', {
       method: 'POST',
-      body: JSON.stringify({ teamId }),
     }).then((r) => r.event),
 
   /** Pause an active clock session (break start). */
-  pause: (teamId: string) =>
+  pause: () =>
     request<{ event: ClockEvent }>('/v1/clock/pause', {
       method: 'POST',
-      body: JSON.stringify({ teamId }),
     }).then((r) => r.event),
 
   /** Resume a paused clock session (break end). */
-  resume: (teamId: string) =>
+  resume: () =>
     request<{ event: ClockEvent }>('/v1/clock/resume', {
       method: 'POST',
-      body: JSON.stringify({ teamId }),
     }).then((r) => r.event),
 
-  /** Get active clock status for a team. */
-  getStatus: (teamId: string) =>
+  /** Get active clock status. */
+  getStatus: () =>
     request<{
       event: ClockEvent;
       workSeconds: number;
       isPaused: boolean;
-    }>(`/v1/clock/status?teamId=${encodeURIComponent(teamId)}`),
+    }>('/v1/clock/status'),
 
   /** Get the current user's active clock event (any team), or null. */
   getActive: () => request<{ event: ClockEvent | null }>('/v1/clock/active').then((r) => r.event),
@@ -766,18 +762,18 @@ export const clockApi = {
     }).then((r) => r.ok),
 
   /** Create a completed manual clock entry for a past time range. */
-  createManualEntry: (data: { teamId: string; startTime: number; endTime: number }) =>
+  createManualEntry: (data: { startTime: number; endTime: number }) =>
     request<{ event: ClockEvent }>('/v1/clock/manual', {
       method: 'POST',
       body: JSON.stringify(data),
     }).then((r) => r.event),
 
-  /** Open a WebSocket connection for live team clock state. Auto-reconnects on drop. */
-  openLiveStream: (teamIds: string[]): AutoReconnectWs =>
+  /** Open a WebSocket connection for the current user's live clock state. */
+  openLiveStream: (): AutoReconnectWs =>
     autoReconnectWs(() => {
       const token = sessionToken.get();
-      const base = `${WS_BASE_URL}/v1/clock/ws?teamIds=${teamIds.map(encodeURIComponent).join(',')}`;
-      return token ? `${base}&token=${encodeURIComponent(token)}` : base;
+      const base = `${WS_BASE_URL}/v1/clock/ws`;
+      return token ? `${base}?token=${encodeURIComponent(token)}` : base;
     }),
 };
 

--- a/src/lib/useClockToggle.test.ts
+++ b/src/lib/useClockToggle.test.ts
@@ -26,7 +26,7 @@ const mockRefetchClock = vi.fn();
 
 function setupTeam(
   opts: {
-    activeClockEvent?: { id: string; teamId: string } | null;
+    activeClockEvent?: { id: string; teamId?: string } | null;
     selectedTeamId?: string | null;
   } = {},
 ) {
@@ -75,24 +75,24 @@ describe('useClockToggle', () => {
   // ── clockIn() ───────────────────────────────────────────────────────────────
 
   describe('clockIn()', () => {
-    it('calls clockApi.start with selectedTeamId then refetchClock', async () => {
+    it('calls clockApi.start then refetchClock', async () => {
       setupTeam({ activeClockEvent: null, selectedTeamId: 'team-abc' });
       const { result } = renderHook(() => useClockToggle());
 
       await act(() => result.current.clockIn());
 
-      expect(mockStart).toHaveBeenCalledWith('team-abc');
+      expect(mockStart).toHaveBeenCalledWith();
       expect(mockRefetchClock).toHaveBeenCalledOnce();
     });
 
-    it('does nothing if selectedTeamId is null', async () => {
+    it('clocks in even if selectedTeamId is null', async () => {
       setupTeam({ activeClockEvent: null, selectedTeamId: null });
       const { result } = renderHook(() => useClockToggle());
 
       await act(() => result.current.clockIn());
 
-      expect(mockStart).not.toHaveBeenCalled();
-      expect(mockRefetchClock).not.toHaveBeenCalled();
+      expect(mockStart).toHaveBeenCalledWith();
+      expect(mockRefetchClock).toHaveBeenCalledOnce();
     });
 
     it('sets clockInLoading=true during the call and false after', async () => {
@@ -121,7 +121,7 @@ describe('useClockToggle', () => {
   // ── clockOut() ──────────────────────────────────────────────────────────────
 
   describe('clockOut()', () => {
-    it("uses the active event's teamId (not selectedTeamId) to stop", async () => {
+    it('calls stop and refetchClock when active event exists', async () => {
       setupTeam({
         activeClockEvent: { id: 'evt1', teamId: 'team-from-event' },
         selectedTeamId: 'team-from-ui',
@@ -130,27 +130,27 @@ describe('useClockToggle', () => {
 
       await act(() => result.current.clockOut());
 
-      expect(mockStop).toHaveBeenCalledWith('team-from-event');
+      expect(mockStop).toHaveBeenCalledWith();
       expect(mockRefetchClock).toHaveBeenCalledOnce();
     });
 
-    it('falls back to selectedTeamId when there is no active event', async () => {
+    it('calls stop when there is no active event', async () => {
       setupTeam({ activeClockEvent: null, selectedTeamId: 'team-fallback' });
       const { result } = renderHook(() => useClockToggle());
 
       await act(() => result.current.clockOut());
 
-      expect(mockStop).toHaveBeenCalledWith('team-fallback');
+      expect(mockStop).toHaveBeenCalledWith();
     });
 
-    it('does nothing when both teamId sources are null', async () => {
+    it('still calls stop when both teamId sources are null', async () => {
       setupTeam({ activeClockEvent: null, selectedTeamId: null });
       const { result } = renderHook(() => useClockToggle());
 
       await act(() => result.current.clockOut());
 
-      expect(mockStop).not.toHaveBeenCalled();
-      expect(mockRefetchClock).not.toHaveBeenCalled();
+      expect(mockStop).toHaveBeenCalledWith();
+      expect(mockRefetchClock).toHaveBeenCalledOnce();
     });
 
     it('shows window.alert and does not rethrow on API error', async () => {

--- a/src/lib/useClockToggle.ts
+++ b/src/lib/useClockToggle.ts
@@ -1,9 +1,7 @@
 /**
  * useClockToggle — Shared clock-in / clock-out logic.
  *
- * Encapsulates the API calls, loading states, and the teamId guard (always
- * prefer the active event's teamId over the currently selected team, since the
- * user may have switched teams after clocking in).
+ * Encapsulates the clock API calls and loading states.
  */
 import { useCallback, useState } from 'react';
 
@@ -11,7 +9,7 @@ import { clockApi } from './api';
 import { useTeam } from './TeamContext';
 
 export function useClockToggle() {
-  const { activeClockEvent, selectedTeamId, refetchClock } = useTeam();
+  const { activeClockEvent, refetchClock } = useTeam();
 
   const [clockInLoading, setClockInLoading] = useState(false);
   const [clockOutLoading, setClockOutLoading] = useState(false);
@@ -20,50 +18,43 @@ export function useClockToggle() {
   const isClockedIn = !!activeClockEvent;
 
   const clockIn = useCallback(async () => {
-    if (!selectedTeamId) return;
     setClockInLoading(true);
     try {
-      await clockApi.start(selectedTeamId);
+      await clockApi.start();
       await refetchClock();
     } finally {
       setClockInLoading(false);
     }
-  }, [selectedTeamId, refetchClock]);
+  }, [refetchClock]);
 
   const clockOut = useCallback(async () => {
-    const teamId = activeClockEvent?.teamId ?? selectedTeamId;
-    if (!teamId) return;
     setClockOutLoading(true);
     try {
-      await clockApi.stop(teamId);
+      await clockApi.stop();
       await refetchClock();
     } catch (err) {
       window.alert(err instanceof Error ? err.message : 'Failed to clock out. Please try again.');
     } finally {
       setClockOutLoading(false);
     }
-  }, [activeClockEvent, selectedTeamId, refetchClock]);
+  }, [refetchClock]);
 
   const pauseClock = useCallback(async () => {
-    const teamId = activeClockEvent?.teamId ?? selectedTeamId;
-    if (!teamId) return;
     setClockPauseLoading(true);
     try {
-      await clockApi.pause(teamId);
+      await clockApi.pause();
       await refetchClock();
     } catch (err) {
       window.alert(err instanceof Error ? err.message : 'Failed to pause clock. Please try again.');
     } finally {
       setClockPauseLoading(false);
     }
-  }, [activeClockEvent, selectedTeamId, refetchClock]);
+  }, [refetchClock]);
 
   const resumeClock = useCallback(async () => {
-    const teamId = activeClockEvent?.teamId ?? selectedTeamId;
-    if (!teamId) return;
     setClockPauseLoading(true);
     try {
-      await clockApi.resume(teamId);
+      await clockApi.resume();
       await refetchClock();
     } catch (err) {
       window.alert(
@@ -72,7 +63,7 @@ export function useClockToggle() {
     } finally {
       setClockPauseLoading(false);
     }
-  }, [activeClockEvent, selectedTeamId, refetchClock]);
+  }, [refetchClock]);
 
   return {
     isClockedIn,


### PR DESCRIPTION
Closes #214 by removing direct team association on ClockEvent.  e.g. Agnostic clock in/out.

- Remove team-scoped clock API requirements for start/stop/pause/resume/status/manual flows.
- Make ClockEvent.teamId optional for legacy compatibility while shifting active-session behavior to user scope.
- Simplify clock websocket updates to authenticated user streams and update frontend consumers accordingly.
- Drop Team column rendering from timesheet tables and update related row components/tests.
- Align backend, frontend, and e2e tests with the new user-scoped clock contract.