### PR TITLE
Enabling push notification when updating things in application related to timesheet

### DIFF
--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -598,8 +598,8 @@ export class ClockService {
     const updated = await coll.findOne({ _id: event._id });
     const updatedBreaks = await findBreaksForEvent(clockEventId);
     if (updated) {
-      this.notifyClockAdmins(requesterId, event.teamId, updated.startTime, "updated").catch(
-        (err) => console.error("[clock.service] notify admins failed:", err)
+      this.notifyClockAdmins(requesterId, event.teamId, updated.startTime, "updated").catch((err) =>
+        console.error("[clock.service] notify admins failed:", err)
       );
     }
     return updated ? toPublicClockEvent(updated, updatedBreaks) : "not-found";

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -246,7 +246,7 @@ export class ClockService {
         notificationService.create({
           userId: adminId,
           title: "Timesheet Update",
-          body: `${actorName} has ${action} a clock session for ${date}`,
+          body: `${actorName} has ${action} a clock session for ${date} in ${team.name}`,
           notificationData: {
             type: "clock-session-changed",
             teamId,

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -4,6 +4,7 @@ import {
   attachmentsCollection,
   clockBreaksCollection,
   clockEventsCollection,
+  profilesCollection,
   teamsCollection,
   usersCollection,
 } from "../models/index.js";
@@ -223,6 +224,39 @@ export type PublicClockEvent = ReturnType<typeof toPublicClockEvent>;
 // ─── ClockService ─────────────────────────────────────────────────────────────
 
 export class ClockService {
+  /** Notify all team admins when a clock session is added or updated. */
+  private async notifyClockAdmins(
+    actorUserId: string,
+    teamId: string,
+    startTime: number,
+    action: "added" | "updated" | "deleted"
+  ): Promise<void> {
+    const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
+    if (!team || !team.admins || team.admins.length === 0) return;
+
+    const profile = await profilesCollection().findOne({ userId: actorUserId, app: "timeharbor" });
+    const actorName =
+      profile?.displayName ||
+      (await usersCollection().findOne({ _id: new ObjectId(actorUserId) }))?.name ||
+      "A team member";
+    const date = new Date(startTime).toISOString().slice(0, 10);
+
+    await Promise.all(
+      team.admins.map((adminId) =>
+        notificationService.create({
+          userId: adminId,
+          title: "Timesheet Update",
+          body: `${actorName} has ${action} a clock session for ${date}`,
+          notificationData: {
+            type: "clock-session-changed",
+            teamId,
+            date,
+          },
+        })
+      )
+    );
+  }
+
   /** Return the active (open) clock event for a user in a team, or null. */
   async getActive(userId: string, teamId: string): Promise<ClockEvent | null> {
     return findActiveClockEventByUserTeam(userId, teamId);
@@ -563,6 +597,11 @@ export class ClockService {
 
     const updated = await coll.findOne({ _id: event._id });
     const updatedBreaks = await findBreaksForEvent(clockEventId);
+    if (updated) {
+      this.notifyClockAdmins(requesterId, event.teamId, updated.startTime, "updated").catch(
+        (err) => console.error("[clock.service] notify admins failed:", err)
+      );
+    }
     return updated ? toPublicClockEvent(updated, updatedBreaks) : "not-found";
   }
 
@@ -595,6 +634,10 @@ export class ClockService {
     if (event.endTime === null) {
       broadcast(event.teamId, null);
     }
+
+    this.notifyClockAdmins(requesterId, event.teamId, event.startTime, "deleted").catch((err) =>
+      console.error("[clock.service] notify admins failed:", err)
+    );
 
     return "ok";
   }
@@ -633,6 +676,9 @@ export class ClockService {
 
     const created = await coll.findOne({ _id: result.insertedId });
     if (!created) return "forbidden";
+    this.notifyClockAdmins(userId, teamId, startTime, "added").catch((err) =>
+      console.error("[clock.service] notify admins failed:", err)
+    );
     return toPublicClockEvent(created, []);
   }
 

--- a/backend/src/services/timer.service.ts
+++ b/backend/src/services/timer.service.ts
@@ -4,7 +4,10 @@ import {
   timersCollection,
   ticketsCollection,
   teamsCollection,
+  profilesCollection,
+  usersCollection,
 } from "../models/index.js";
+import { notificationService } from "./notification.service.js";
 import type { WorkItem } from "../models/work-item.model.js";
 import type { Timer } from "../models/timer.model.js";
 
@@ -83,6 +86,43 @@ export function toUtcDateKey(epochMs: number): string {
 // ─── TimerService ─────────────────────────────────────────────────────────────
 
 export class TimerService {
+  /** Notify all team admins when a timesheet entry is created, updated, or deleted. */
+  private async notifyTimesheetAdmins(
+    actorUserId: string,
+    ticketId: string,
+    date: string,
+    action: "added" | "updated" | "deleted"
+  ): Promise<void> {
+    if (!isValidId(ticketId)) return;
+    const ticket = await ticketsCollection().findOne({ _id: new ObjectId(ticketId) });
+    if (!ticket || !isValidId(ticket.teamId)) return;
+
+    const team = await teamsCollection().findOne({ _id: new ObjectId(ticket.teamId) });
+    if (!team || !team.admins || team.admins.length === 0) return;
+
+    const profile = await profilesCollection().findOne({ userId: actorUserId, app: "timeharbor" });
+    const actorName =
+      profile?.displayName ||
+      (await usersCollection().findOne({ _id: new ObjectId(actorUserId) }))?.name ||
+      "A team member";
+
+    await Promise.all(
+      team.admins.map((adminId) =>
+        notificationService.create({
+          userId: adminId,
+          title: "Timesheet Update",
+          body: `${actorName} has ${action} a timesheet entry for ${date}`,
+          notificationData: {
+            type: "timesheet-entry-changed",
+            ticketId,
+            date,
+            teamId: ticket.teamId,
+          },
+        })
+      )
+    );
+  }
+
   /**
    * Create a new WorkItem for { userId, ticketId, date }.
    * Returns "not-found" if the ticket does not exist or "forbidden" if the
@@ -114,6 +154,9 @@ export class TimerService {
       createdAt: new Date(),
     };
     await workItemsCollection().insertOne(doc);
+    this.notifyTimesheetAdmins(userId, ticketId, date, "added").catch((err) =>
+      console.error("[timer.service] notify admins failed:", err)
+    );
     return doc;
   }
 
@@ -512,6 +555,9 @@ export class TimerService {
     const entryResult = await workItemsCollection().deleteOne({ _id: entryObjectId, userId });
 
     broadcastTimerUpdate(userId);
+    this.notifyTimesheetAdmins(userId, entry.ticketId, entry.date, "deleted").catch((err) =>
+      console.error("[timer.service] notify admins failed:", err)
+    );
 
     return {
       deletedEntry: entryResult.deletedCount === 1,
@@ -592,7 +638,13 @@ export class TimerService {
       }
     }
 
-    return (await workItemsCollection().findOne({ _id: entryOid }))!;
+    const updated = (await workItemsCollection().findOne({ _id: entryOid }))!;
+    const finalTicketId =
+      updates.ticketId && updates.ticketId !== entry.ticketId ? updates.ticketId : entry.ticketId;
+    this.notifyTimesheetAdmins(userId, finalTicketId, updated.date, "updated").catch((err) =>
+      console.error("[timer.service] notify admins failed:", err)
+    );
+    return updated;
   }
 
   /**

--- a/backend/src/services/timer.service.ts
+++ b/backend/src/services/timer.service.ts
@@ -111,7 +111,7 @@ export class TimerService {
         notificationService.create({
           userId: adminId,
           title: "Timesheet Update",
-          body: `${actorName} has ${action} a timesheet entry for ${date}`,
+          body: `${actorName} has ${action} a timesheet entry for ${date} in ${team.name}`,
           notificationData: {
             type: "timesheet-entry-changed",
             ticketId,

--- a/e2e/timesheet-notifications.spec.ts
+++ b/e2e/timesheet-notifications.spec.ts
@@ -105,7 +105,7 @@ async function createManualClockSession(
 ): Promise<{ id: string; startTime: number }> {
   const now = Date.now();
   const startTime = now - 3_600_000; // 1 hour ago
-  const endTime = now - 1_800_000;   // 30 min ago
+  const endTime = now - 1_800_000; // 30 min ago
   const res = await page.request.post(`${API_BASE}/clock/manual`, {
     data: { teamId, startTime, endTime },
   });
@@ -214,7 +214,7 @@ test.describe('Clock Session Notifications', () => {
       await bobPage.request.put(`${API_BASE}/clock/${eventId}/times`, {
         data: {
           startTime: now - 7_200_000, // 2 hours ago
-          endTime: now - 3_600_000,   // 1 hour ago
+          endTime: now - 3_600_000, // 1 hour ago
         },
       });
 

--- a/e2e/timesheet-notifications.spec.ts
+++ b/e2e/timesheet-notifications.spec.ts
@@ -1,0 +1,417 @@
+/**
+ * Timesheet Notification E2E
+ *
+ * Verifies that team admins receive push notifications when a team member:
+ *  - Adds a manual clock session
+ *  - Edits a clock session
+ *  - Deletes a clock session
+ *  - Adds a work (timesheet) entry
+ *  - Edits a work entry
+ *  - Deletes a work entry
+ *
+ * Setup (self-provisioned per test):
+ *  Alice Admin  (alice@example.com) — creates team → becomes admin
+ *  Bob Builder  (bob@example.com)   — joins team via code → becomes member
+ *
+ * Bob performs each action; Alice's notification inbox is asserted after.
+ * The team is deleted in a finally block so each test is isolated.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+const BOB_EMAIL = 'bob@example.com';
+const BOB_PASSWORD = 'Password1!';
+const ALICE_EMAIL = 'alice@example.com';
+const ALICE_PASSWORD = 'Password1!';
+const API_BASE = 'http://localhost:4000/v1';
+const FRONTEND_BASE = 'http://localhost:3000';
+
+type Notification = {
+  id: string;
+  title: string;
+  body: string;
+  read: boolean;
+  data?: Record<string, unknown>;
+};
+
+// ─── Auth helpers ─────────────────────────────────────────────────────────────
+
+/** Sign in via the API directly — sets the session cookie in the page's context. */
+async function loginAs(page: Page, email: string, password: string) {
+  const res = await page.request.post(`http://localhost:4000/api/auth/sign-in/email`, {
+    data: { email, password },
+  });
+  if (!res.ok()) {
+    throw new Error(`Login failed for ${email}: ${res.status()} ${await res.text()}`);
+  }
+}
+
+// ─── Notification helpers ─────────────────────────────────────────────────────
+
+async function getNotifications(page: Page): Promise<Notification[]> {
+  const res = await page.request.get(`${API_BASE}/notifications`);
+  const body = (await res.json()) as { notifications: Notification[] };
+  return body.notifications ?? [];
+}
+
+async function clearNotifications(page: Page): Promise<void> {
+  const notifications = await getNotifications(page);
+  if (!notifications.length) return;
+  await page.request.delete(`${API_BASE}/notifications`, {
+    data: { ids: notifications.map((n) => n.id) },
+  });
+}
+
+// ─── Team lifecycle helpers ────────────────────────────────────────────────────
+
+/**
+ * Alice creates a uniquely-named team (she becomes admin).
+ * Bob joins via the team code (he becomes member).
+ * Returns { teamId, teamName } for use in assertions.
+ */
+async function setupTestTeam(
+  alicePage: Page,
+  bobPage: Page,
+): Promise<{ teamId: string; teamName: string }> {
+  const teamName = `E2E Notifications ${Date.now()}`;
+  const createRes = await alicePage.request.post(`${API_BASE}/teams`, {
+    data: { name: teamName },
+  });
+  if (!createRes.ok()) {
+    throw new Error(`Team creation failed: ${createRes.status()} ${await createRes.text()}`);
+  }
+  const { team } = (await createRes.json()) as { team: { id: string; code: string } };
+
+  const joinRes = await bobPage.request.post(`${API_BASE}/teams/join`, {
+    data: { teamCode: team.code },
+  });
+  if (!joinRes.ok()) {
+    throw new Error(`Bob failed to join team: ${joinRes.status()} ${await joinRes.text()}`);
+  }
+
+  return { teamId: team.id, teamName };
+}
+
+/** Alice (admin) deletes the test team — call in a finally block. */
+async function teardownTestTeam(alicePage: Page, teamId: string): Promise<void> {
+  await alicePage.request.delete(`${API_BASE}/teams/${teamId}`).catch(() => {
+    // best-effort cleanup — ignore failures
+  });
+}
+
+async function createManualClockSession(
+  page: Page,
+  teamId: string,
+): Promise<{ id: string; startTime: number }> {
+  const now = Date.now();
+  const startTime = now - 3_600_000; // 1 hour ago
+  const endTime = now - 1_800_000;   // 30 min ago
+  const res = await page.request.post(`${API_BASE}/clock/manual`, {
+    data: { teamId, startTime, endTime },
+  });
+  const { event } = (await res.json()) as { event: { id: string; startTime: number } };
+  return { id: event.id, startTime: event.startTime };
+}
+
+async function createTicketInDevelopers(page: Page, teamId: string): Promise<string> {
+  const res = await page.request.post(`${API_BASE}/tickets`, {
+    data: { teamId, title: `E2E notification test ticket ${Date.now()}` },
+  });
+  const { ticket } = (await res.json()) as { ticket: { id: string } };
+  return ticket.id;
+}
+
+async function createWorkEntry(page: Page, ticketId: string, date: string): Promise<string> {
+  const res = await page.request.post(`${API_BASE}/timers/entries`, {
+    data: { ticketId, date, note: 'e2e notification test' },
+  });
+  const { entry } = (await res.json()) as { entry: { id: string } };
+  return entry.id;
+}
+
+// ─── Assertion helper ─────────────────────────────────────────────────────────
+
+async function waitForNotification(
+  alicePage: Page,
+  matcher: (n: Notification) => boolean,
+  timeoutMs = 3000,
+): Promise<Notification> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const notifications = await getNotifications(alicePage);
+    const found = notifications.find(matcher);
+    if (found) return found;
+    await alicePage.waitForTimeout(300);
+  }
+  throw new Error('Expected notification not received within timeout');
+}
+
+// ─── Clock Session Notification Tests ────────────────────────────────────────
+
+test.describe('Clock Session Notifications', () => {
+  test.setTimeout(60000);
+
+  test('admin notified when member adds a manual clock session', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+      await clearNotifications(alicePage);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+
+      await createManualClockSession(bobPage, teamId);
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('added') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.title).toBe('Timesheet Update');
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('added');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('clock-session-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+
+  test('admin notified when member edits a clock session', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+      const { id: eventId } = await createManualClockSession(bobPage, teamId);
+
+      await clearNotifications(alicePage);
+
+      const now = Date.now();
+      await bobPage.request.put(`${API_BASE}/clock/${eventId}/times`, {
+        data: {
+          startTime: now - 7_200_000, // 2 hours ago
+          endTime: now - 3_600_000,   // 1 hour ago
+        },
+      });
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('updated') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('updated');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('clock-session-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+
+  test('admin notified when member deletes a clock session', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+      const { id: eventId } = await createManualClockSession(bobPage, teamId);
+
+      await clearNotifications(alicePage);
+
+      await bobPage.request.delete(`${API_BASE}/clock/${eventId}`);
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('deleted') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('deleted');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('clock-session-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+});
+
+// ─── Work Entry Notification Tests ───────────────────────────────────────────
+
+test.describe('Work Entry Notifications', () => {
+  test.setTimeout(60000);
+
+  test('admin notified when member adds a work entry', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+      await clearNotifications(alicePage);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+      const ticketId = await createTicketInDevelopers(bobPage, teamId);
+      const today = new Date().toISOString().slice(0, 10);
+
+      await createWorkEntry(bobPage, ticketId, today);
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('added') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.title).toBe('Timesheet Update');
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('added');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('timesheet-entry-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+
+  test('admin notified when member edits a work entry', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+      const ticketId = await createTicketInDevelopers(bobPage, teamId);
+      const today = new Date().toISOString().slice(0, 10);
+      const entryId = await createWorkEntry(bobPage, ticketId, today);
+
+      await clearNotifications(alicePage);
+
+      await bobPage.request.patch(`${API_BASE}/timers/entries/${entryId}`, {
+        data: { note: 'updated via e2e test' },
+      });
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('updated') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('updated');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('timesheet-entry-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+
+  test('admin notified when member deletes a work entry', async ({ browser }) => {
+    const bobCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const aliceCtx = await browser.newContext({ baseURL: FRONTEND_BASE });
+    const bobPage = await bobCtx.newPage();
+    const alicePage = await aliceCtx.newPage();
+
+    let teamId: string | null = null;
+    try {
+      await Promise.all([
+        loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+        loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      ]);
+
+      const { teamId: tid, teamName } = await setupTestTeam(alicePage, bobPage);
+      teamId = tid;
+      const ticketId = await createTicketInDevelopers(bobPage, teamId);
+      const today = new Date().toISOString().slice(0, 10);
+      const entryId = await createWorkEntry(bobPage, ticketId, today);
+
+      await clearNotifications(alicePage);
+
+      await bobPage.request.delete(`${API_BASE}/timers/entries/${entryId}`);
+
+      const notification = await waitForNotification(
+        alicePage,
+        (n) =>
+          n.title === 'Timesheet Update' &&
+          n.body.includes('Bob Builder') &&
+          n.body.includes('deleted') &&
+          n.body.includes(teamName),
+      );
+
+      expect(notification.body).toContain('Bob Builder');
+      expect(notification.body).toContain('deleted');
+      expect(notification.body).toContain(teamName);
+      expect(notification.data?.type).toBe('timesheet-entry-changed');
+    } finally {
+      if (teamId) await teardownTestTeam(alicePage, teamId);
+      await bobCtx.close();
+      await aliceCtx.close();
+    }
+  });
+});


### PR DESCRIPTION
This pull request introduces notifications for team admins when timesheet entries or clock sessions are added, updated, or deleted. The main changes are the addition of helper methods to send notifications and their integration into the relevant service methods for both the clock and timer features.

**Notifications for Admins on Timesheet/Clock Session Changes**

*Clock Service (`clock.service.ts`):*
- Added a `notifyClockAdmins` method to send notifications to all team admins when a clock session is added, updated, or deleted. The notification includes the actor's display name, the action performed, the date, and the team name.
- Integrated `notifyClockAdmins` into the clock session add, update, and delete flows, so admins are notified whenever these actions occur. 
- Updated imports to include `profilesCollection` for retrieving user display names.

*Timer Service (`timer.service.ts`):*
- Added a `notifyTimesheetAdmins` method to send notifications to all team admins when a timesheet entry is added, updated, or deleted. The notification includes the actor's display name, the action performed, the date, and the team name.
- Integrated `notifyTimesheetAdmins` into the timesheet entry add, update, and delete flows, so admins are notified whenever these actions occur. 
- Updated imports to include `profilesCollection`, `usersCollection`, and `notificationService` for notification and user display name support.

These changes ensure that team admins are kept informed about important timesheet and clock session activities in real time.