### PR TITLE
Add an autoclockout feature with a push notification

### DIFF
--- a/backend/migrations/20260601_000000_add-shift-reminder-fields.cjs
+++ b/backend/migrations/20260601_000000_add-shift-reminder-fields.cjs
@@ -1,0 +1,46 @@
+/**
+ * Migration: Add shift-end reminder fields to clockevents
+ *
+ * Adds four new nullable fields used by the ClockMonitorService 7h45m
+ * shift-end reminder / auto-clockout feature:
+ *   notifiedAt7h45m          – epoch ms when the first 7h45m reminder was sent
+ *   shiftAutoClockoutWorkSecs – work-second threshold at which auto-clockout fires
+ *   shiftNextReminderWorkSecs – work-second threshold for the next 2h repeat reminder
+ *   shiftReminderResponse     – last user response ("agreed" | "disagreed")
+ */
+module.exports = {
+  async up(db) {
+    await db.collection("clockevents").updateMany(
+      {
+        $or: [
+          { notifiedAt7h45m: { $exists: false } },
+          { shiftAutoClockoutWorkSecs: { $exists: false } },
+          { shiftNextReminderWorkSecs: { $exists: false } },
+          { shiftReminderResponse: { $exists: false } },
+        ],
+      },
+      {
+        $set: {
+          notifiedAt7h45m: null,
+          shiftAutoClockoutWorkSecs: null,
+          shiftNextReminderWorkSecs: null,
+          shiftReminderResponse: null,
+        },
+      }
+    );
+  },
+
+  async down(db) {
+    await db.collection("clockevents").updateMany(
+      {},
+      {
+        $unset: {
+          notifiedAt7h45m: "",
+          shiftAutoClockoutWorkSecs: "",
+          shiftNextReminderWorkSecs: "",
+          shiftReminderResponse: "",
+        },
+      }
+    );
+  },
+};

--- a/backend/src/models/clock.model.ts
+++ b/backend/src/models/clock.model.ts
@@ -33,6 +33,14 @@ export interface ClockEvent {
   accumulatedTime: number; // seconds — computed at clock-out (span minus deducted breaks)
   notifiedAt4h?: number | null; // epoch ms when 4h reminder was sent
   endTime: number | null; // epoch ms — null = still clocked in
+  /** epoch ms when the 7h45m shift-end reminder was first sent */
+  notifiedAt7h45m?: number | null;
+  /** work-second threshold: auto-clockout fires when workSeconds >= this value */
+  shiftAutoClockoutWorkSecs?: number | null;
+  /** work-second threshold: next 2h repeat reminder fires when workSeconds >= this value */
+  shiftNextReminderWorkSecs?: number | null;
+  /** last user response to a shift-end reminder; used for the admin notification message */
+  shiftReminderResponse?: "agreed" | "disagreed" | null;
 }
 
 // ─── ClockEvent helpers ────────────────────────────────────────────────────────

--- a/backend/src/routes/clock.ts
+++ b/backend/src/routes/clock.ts
@@ -35,6 +35,9 @@ const clockEventShape = {
     totalBreakSeconds: { type: "number" },
     isPaused: { type: "boolean" },
     endTime: { type: "number", nullable: true },
+    shiftReminderResponse: { type: "string", nullable: true },
+    shiftAutoClockoutWorkSecs: { type: "number", nullable: true },
+    shiftNextReminderWorkSecs: { type: "number", nullable: true },
   },
 };
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -3,9 +3,14 @@ import { z } from "zod";
 import { auth } from "../lib/auth.js";
 import { notificationService, subscribe } from "../services/notification.service.js";
 import { pushService } from "../services/push.service.js";
+import { respondToShiftReminder } from "../services/clock.service.js";
 
 const deleteSchema = z.object({
   ids: z.array(z.string().min(1)).min(1),
+});
+
+const shiftRespondSchema = z.object({
+  action: z.enum(["agree", "disagree"]),
 });
 
 const inviteRespondSchema = z.object({
@@ -89,6 +94,25 @@ export async function notificationRoutes(app: FastifyInstance) {
     if (result === "not-found") return reply.status(404).send({ error: "Not found" });
     if (result === "forbidden") return reply.status(403).send({ error: "Forbidden" });
     if (result === "bad-request") return reply.status(400).send({ error: "Not a team invite" });
+    return reply.send({ ok: true });
+  });
+
+  // POST /v1/notifications/:id/shift-respond — agree or disagree to shift-end auto-clockout
+  app.post("/notifications/:id/shift-respond", async (req, reply) => {
+    const session = await auth.api.getSession({ headers: req.headers as any });
+    if (!session?.user) return reply.status(401).send({ error: "Unauthorized" });
+
+    const { id } = req.params as { id: string };
+    const parsed = shiftRespondSchema.safeParse(req.body);
+    if (!parsed.success) {
+      return reply.status(400).send({ error: parsed.error.issues[0]?.message ?? "Invalid" });
+    }
+
+    const result = await respondToShiftReminder(session.user.id, id, parsed.data.action);
+    if (result === "not-found") return reply.status(404).send({ error: "Not found" });
+    if (result === "forbidden") return reply.status(403).send({ error: "Forbidden" });
+    if (result === "bad-request") return reply.status(400).send({ error: "Not a shift-end reminder" });
+    if (result === "already-closed") return reply.status(409).send({ error: "Clock session already closed" });
     return reply.send({ ok: true });
   });
 

--- a/backend/src/routes/notifications.ts
+++ b/backend/src/routes/notifications.ts
@@ -111,8 +111,10 @@ export async function notificationRoutes(app: FastifyInstance) {
     const result = await respondToShiftReminder(session.user.id, id, parsed.data.action);
     if (result === "not-found") return reply.status(404).send({ error: "Not found" });
     if (result === "forbidden") return reply.status(403).send({ error: "Forbidden" });
-    if (result === "bad-request") return reply.status(400).send({ error: "Not a shift-end reminder" });
-    if (result === "already-closed") return reply.status(409).send({ error: "Clock session already closed" });
+    if (result === "bad-request")
+      return reply.status(400).send({ error: "Not a shift-end reminder" });
+    if (result === "already-closed")
+      return reply.status(409).send({ error: "Clock session already closed" });
     return reply.send({ ok: true });
   });
 

--- a/backend/src/services/clock-monitor.service.ts
+++ b/backend/src/services/clock-monitor.service.ts
@@ -1,23 +1,28 @@
-import { clockEventsCollection } from "../models/index.js";
+import { clockEventsCollection, teamsCollection, usersCollection } from "../models/index.js";
 import type { ClockEvent } from "../models/clock.model.js";
 import { findBreaksForEvents } from "../models/clock.model.js";
-import { computeWorkSeconds } from "./clock.service.js";
+import { clockService, computeWorkSeconds } from "./clock.service.js";
 import { notificationService } from "./notification.service.js";
+import { ObjectId } from "mongodb";
 
 const FOUR_HOURS_SECONDS = 4 * 60 * 60;
+const SEVEN_HOURS_45_MIN_SECONDS = 7 * 3600 + 45 * 60; // 27 900
+const EIGHT_HOURS_SECONDS = 8 * 3600; // 28 800 — auto-clockout threshold (15 min window)
 
 class ClockMonitorService {
   async checkAndEnforce(now = Date.now()): Promise<{
     reminded4h: number;
+    reminded7h45m: number;
+    reminded2hCycle: number;
+    autoClockedOut: number;
   }> {
     const coll = clockEventsCollection();
-    const activeEvents = await coll
-      .find({
-        endTime: null,
-      })
-      .toArray();
+    const activeEvents = await coll.find({ endTime: null }).toArray();
 
     let reminded4h = 0;
+    let reminded7h45m = 0;
+    let reminded2hCycle = 0;
+    let autoClockedOut = 0;
 
     const activeIds = activeEvents.map((e) => e._id.toHexString());
     const allBreaks = await findBreaksForEvents(activeIds);
@@ -32,6 +37,7 @@ class ClockMonitorService {
       const breaks = breaksByEventId.get(event._id.toHexString()) ?? [];
       const workSeconds = computeWorkSeconds(event as ClockEvent, breaks, now);
 
+      // ── Check A: 4-hour break reminder ──────────────────────────────────────
       if (workSeconds >= FOUR_HOURS_SECONDS && event.notifiedAt4h == null) {
         const locked = await coll.updateOne(
           { _id: event._id, endTime: null, notifiedAt4h: null },
@@ -52,10 +58,148 @@ class ClockMonitorService {
           });
         }
       }
+
+      // ── Check B: 7h45m first shift-end reminder ──────────────────────────────
+      if (workSeconds >= SEVEN_HOURS_45_MIN_SECONDS && event.notifiedAt7h45m == null) {
+        const locked = await coll.updateOne(
+          { _id: event._id, endTime: null, notifiedAt7h45m: null },
+          {
+            $set: {
+              notifiedAt7h45m: now,
+              shiftAutoClockoutWorkSecs: EIGHT_HOURS_SECONDS,
+            },
+          }
+        );
+        if (locked.modifiedCount === 1) {
+          reminded7h45m += 1;
+          await notificationService.create({
+            userId: event.userId,
+            title: "Shift End Reminder",
+            body: "You have worked 7 hours 45 minutes. Agree to clock out at 8 hours, or continue working.",
+            notificationData: {
+              type: "shift-end-reminder",
+              teamId: event.teamId,
+              clockEventId: event._id.toHexString(),
+              url: "/app/clock",
+            },
+          });
+        }
+      }
+
+      // ── Check C: auto-clockout when threshold reached (agreed or ignored) ────
+      if (
+        event.shiftAutoClockoutWorkSecs != null &&
+        workSeconds >= event.shiftAutoClockoutWorkSecs
+      ) {
+        const threshold = event.shiftAutoClockoutWorkSecs;
+        const locked = await coll.updateOne(
+          { _id: event._id, endTime: null, shiftAutoClockoutWorkSecs: threshold },
+          { $set: { shiftAutoClockoutWorkSecs: null } }
+        );
+        if (locked.modifiedCount === 1) {
+          autoClockedOut += 1;
+          const wasAgreed = event.shiftReminderResponse === "agreed";
+
+          // Delegate to clockService.stop() — closes timers, classifies breaks, notifies admins
+          await clockService.stop(event.userId, event.teamId);
+
+          // Notify the user about the auto-clockout
+          const userBody = wasAgreed
+            ? "You have been automatically clocked out as you agreed."
+            : "You have been automatically clocked out. No response was received to the shift-end reminder.";
+          await notificationService.create({
+            userId: event.userId,
+            title: "Auto Clocked Out",
+            body: userBody,
+            notificationData: {
+              type: "auto-clock-out",
+              teamId: event.teamId,
+              clockEventId: event._id.toHexString(),
+              url: "/app/clock",
+            },
+          });
+
+          // Additional admin notification with reason
+          if (!wasAgreed) {
+            await _notifyAdminsShiftIgnored(event.userId, event.teamId);
+          }
+        }
+      }
+
+      // ── Check D: 2h repeat reminder after user disagreed ────────────────────
+      if (
+        event.shiftNextReminderWorkSecs != null &&
+        workSeconds >= event.shiftNextReminderWorkSecs
+      ) {
+        const nextThreshold = event.shiftNextReminderWorkSecs;
+        const locked = await coll.updateOne(
+          { _id: event._id, endTime: null, shiftNextReminderWorkSecs: nextThreshold },
+          {
+            $set: {
+              shiftNextReminderWorkSecs: null,
+              // 15-minute response window from this reminder's threshold
+              shiftAutoClockoutWorkSecs: nextThreshold + 15 * 60,
+              shiftReminderResponse: null,
+            },
+          }
+        );
+        if (locked.modifiedCount === 1) {
+          reminded2hCycle += 1;
+          const totalHours = Math.floor(nextThreshold / 3600);
+          const totalMins = Math.floor((nextThreshold % 3600) / 60);
+          const timeLabel =
+            totalMins > 0 ? `${totalHours} hours ${totalMins} minutes` : `${totalHours} hours`;
+          await notificationService.create({
+            userId: event.userId,
+            title: "Shift End Reminder",
+            body: `You have worked ${timeLabel}. Agree to clock out, or continue working.`,
+            notificationData: {
+              type: "shift-end-reminder",
+              teamId: event.teamId,
+              clockEventId: event._id.toHexString(),
+              url: "/app/clock",
+            },
+          });
+        }
+      }
     }
 
-    return { reminded4h };
+    return { reminded4h, reminded7h45m, reminded2hCycle, autoClockedOut };
   }
+}
+
+/** Send an admin notification when a user was auto-clocked out without responding. */
+async function _notifyAdminsShiftIgnored(userId: string, teamId: string): Promise<void> {
+  if (!ObjectId.isValid(teamId)) return;
+  const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
+  if (!team || !team.admins || team.admins.length === 0) return;
+
+  const user = ObjectId.isValid(userId)
+    ? await usersCollection().findOne({ _id: new ObjectId(userId) })
+    : null;
+  const userName = user?.name ?? user?.email?.split("@")[0] ?? "A team member";
+
+  await Promise.all(
+    (team.admins as string[])
+      .filter((adminId) => adminId !== userId)
+      .map((adminId) =>
+        notificationService
+          .create({
+            userId: adminId,
+            title: "Auto Clocked Out",
+            body: `${userName} was automatically clocked out of ${team.name} — no response to the shift-end reminder.`,
+            notificationData: {
+              type: "auto-clock-out-admin",
+              userId,
+              userName,
+              teamId,
+              teamName: team.name,
+              url: "/app/clock",
+            },
+          })
+          .catch(() => {})
+      )
+  );
 }
 
 export const clockMonitorService = new ClockMonitorService();

--- a/backend/src/services/clock-monitor.service.ts
+++ b/backend/src/services/clock-monitor.service.ts
@@ -119,8 +119,10 @@ class ClockMonitorService {
             },
           });
 
-          // Additional admin notification with reason
-          if (!wasAgreed) {
+          // Notify admins — different message depending on whether user agreed or ignored
+          if (wasAgreed) {
+            await _notifyAdminsShiftAgreed(event.userId, event.teamId);
+          } else {
             await _notifyAdminsShiftIgnored(event.userId, event.teamId);
           }
         }
@@ -166,6 +168,40 @@ class ClockMonitorService {
 
     return { reminded4h, reminded7h45m, reminded2hCycle, autoClockedOut };
   }
+}
+
+/** Send an admin notification when a user was auto-clocked out after agreeing to the reminder. */
+async function _notifyAdminsShiftAgreed(userId: string, teamId: string): Promise<void> {
+  if (!ObjectId.isValid(teamId)) return;
+  const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
+  if (!team || !team.admins || team.admins.length === 0) return;
+
+  const user = ObjectId.isValid(userId)
+    ? await usersCollection().findOne({ _id: new ObjectId(userId) })
+    : null;
+  const userName = user?.name ?? user?.email?.split("@")[0] ?? "A team member";
+
+  await Promise.all(
+    (team.admins as string[])
+      .filter((adminId) => adminId !== userId)
+      .map((adminId) =>
+        notificationService
+          .create({
+            userId: adminId,
+            title: "Auto Clocked Out",
+            body: `${userName} was automatically clocked out of ${team.name} after agreeing to the shift-end reminder.`,
+            notificationData: {
+              type: "auto-clock-out-admin",
+              userId,
+              userName,
+              teamId,
+              teamName: team.name,
+              url: "/app/clock",
+            },
+          })
+          .catch(() => {})
+      )
+  );
 }
 
 /** Send an admin notification when a user was auto-clocked out without responding. */

--- a/backend/src/services/clock-monitor.service.ts
+++ b/backend/src/services/clock-monitor.service.ts
@@ -98,7 +98,12 @@ class ClockMonitorService {
         );
         if (locked.modifiedCount === 1) {
           autoClockedOut += 1;
-          const wasAgreed = event.shiftReminderResponse === "agreed";
+          // Re-read shiftReminderResponse from DB after acquiring the lock.
+          // The user may have responded via /shift-respond between the initial
+          // activeEvents query and this updateOne, so the in-memory value could
+          // be stale and cause the wrong user/admin message to be sent.
+          const fresh = await coll.findOne({ _id: event._id });
+          const wasAgreed = fresh?.shiftReminderResponse === "agreed";
 
           // Delegate to clockService.stop() — closes timers, classifies breaks, notifies admins
           await clockService.stop(event.userId, event.teamId);

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -4,6 +4,7 @@ import {
   attachmentsCollection,
   clockBreaksCollection,
   clockEventsCollection,
+  notificationsCollection,
   profilesCollection,
   teamsCollection,
   usersCollection,
@@ -216,6 +217,9 @@ export function toPublicClockEvent(e: ClockEvent, breaks: ClockBreakInterval[]) 
     totalBreakSeconds,
     isPaused,
     endTime,
+    shiftReminderResponse: e.shiftReminderResponse ?? null,
+    shiftAutoClockoutWorkSecs: e.shiftAutoClockoutWorkSecs ?? null,
+    shiftNextReminderWorkSecs: e.shiftNextReminderWorkSecs ?? null,
   };
 }
 
@@ -768,3 +772,66 @@ export class ClockService {
 }
 
 export const clockService = new ClockService();
+
+/**
+ * Handle a user's agree/disagree response to a shift-end reminder notification.
+ * Called from the notifications route: POST /v1/notifications/:id/shift-respond
+ *
+ * agree   — marks response; shiftAutoClockoutWorkSecs stays → monitor clocks out at 8h mark
+ * disagree — clears the 8h threshold; schedules next reminder 2h from now in work-seconds
+ */
+export async function respondToShiftReminder(
+  userId: string,
+  notificationId: string,
+  action: "agree" | "disagree"
+): Promise<"ok" | "not-found" | "forbidden" | "bad-request" | "already-closed"> {
+  if (!ObjectId.isValid(notificationId)) return "not-found";
+
+  const notification = await notificationsCollection().findOne({
+    _id: new ObjectId(notificationId),
+  });
+  if (!notification) return "not-found";
+  if (notification.userId !== userId) return "forbidden";
+
+  const data = (notification.data ?? {}) as Record<string, unknown>;
+  if (data.type !== "shift-end-reminder") return "bad-request";
+
+  const clockEventId = typeof data.clockEventId === "string" ? data.clockEventId : "";
+  if (!clockEventId || !ObjectId.isValid(clockEventId)) return "bad-request";
+
+  const coll = clockEventsCollection();
+  const event = await coll.findOne({ _id: new ObjectId(clockEventId) });
+  if (!event) return "not-found";
+  if (event.endTime !== null) return "already-closed";
+  if (event.userId !== userId) return "forbidden";
+
+  if (action === "agree") {
+    // Mark response — shiftAutoClockoutWorkSecs stays set, monitor will clock out at the threshold
+    await coll.updateOne(
+      { _id: event._id },
+      { $set: { shiftReminderResponse: "agreed" } }
+    );
+  } else {
+    // Disagree: cancel the upcoming auto-clockout; schedule next reminder 2h from now (in work-seconds)
+    const breaks = await findBreaksForEvent(clockEventId);
+    const currentWorkSecs = computeWorkSeconds(event, breaks, Date.now());
+    await coll.updateOne(
+      { _id: event._id },
+      {
+        $set: {
+          shiftReminderResponse: "disagreed",
+          shiftAutoClockoutWorkSecs: null,
+          shiftNextReminderWorkSecs: currentWorkSecs + 2 * 3600,
+        },
+      }
+    );
+  }
+
+  // Delete the notification after processing
+  await notificationsCollection().deleteOne({
+    _id: new ObjectId(notificationId),
+    userId,
+  });
+
+  return "ok";
+}

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -806,17 +806,20 @@ export async function respondToShiftReminder(
   if (event.userId !== userId) return "forbidden";
 
   if (action === "agree") {
-    // Mark response — shiftAutoClockoutWorkSecs stays set, monitor will clock out at the threshold
-    await coll.updateOne(
-      { _id: event._id },
+    // Mark response — shiftAutoClockoutWorkSecs stays set, monitor will clock out at the threshold.
+    // Guard endTime: null so a concurrent auto-clockout doesn't update a closed event.
+    const result = await coll.updateOne(
+      { _id: event._id, endTime: null },
       { $set: { shiftReminderResponse: "agreed" } }
     );
+    if (result.modifiedCount === 0) return "already-closed";
   } else {
-    // Disagree: cancel the upcoming auto-clockout; schedule next reminder 2h from now (in work-seconds)
+    // Disagree: cancel the upcoming auto-clockout; schedule next reminder 2h from now (in work-seconds).
+    // Guard endTime: null so a concurrent auto-clockout doesn't update a closed event.
     const breaks = await findBreaksForEvent(clockEventId);
     const currentWorkSecs = computeWorkSeconds(event, breaks, Date.now());
-    await coll.updateOne(
-      { _id: event._id },
+    const result = await coll.updateOne(
+      { _id: event._id, endTime: null },
       {
         $set: {
           shiftReminderResponse: "disagreed",
@@ -825,6 +828,7 @@ export async function respondToShiftReminder(
         },
       }
     );
+    if (result.modifiedCount === 0) return "already-closed";
   }
 
   // Delete the notification after processing

--- a/e2e/shift-reminder.spec.ts
+++ b/e2e/shift-reminder.spec.ts
@@ -83,7 +83,7 @@ async function loginViaApi(
       'Content-Type': 'application/json',
       // better-auth's CSRF protection requires a trusted Origin header.
       // Browser requests include this automatically; Node.js fetch does not.
-      'Origin': 'http://localhost:3000',
+      Origin: 'http://localhost:3000',
     },
     body: JSON.stringify({ email, password }),
   });
@@ -92,10 +92,7 @@ async function loginViaApi(
   return body.token;
 }
 
-async function ensureClockedOut(
-  page: import('@playwright/test').Page,
-  token: string,
-) {
+async function ensureClockedOut(page: import('@playwright/test').Page, token: string) {
   const res = await page.request.get(`${API_BASE}/clock/active`, {
     headers: authHeaders(token),
   });
@@ -119,9 +116,7 @@ async function clearShiftReminderNotifications(
     notifications: Array<{ id: string; data?: Record<string, unknown> }>;
   };
   const ids = notifications
-    .filter((n) =>
-      n.data?.type === 'shift-end-reminder' || n.data?.type === 'auto-clock-out',
-    )
+    .filter((n) => n.data?.type === 'shift-end-reminder' || n.data?.type === 'auto-clock-out')
     .map((n) => n.id);
   if (ids.length === 0) return;
   await page.request.delete(`${API_BASE}/notifications`, {
@@ -239,9 +234,7 @@ test.describe('Shift-End Reminder', () => {
     await expect(dialog.getByRole('heading', { name: 'Shift End Reminder' })).toBeVisible();
 
     // Body — the notification message
-    await expect(
-      dialog.getByText('You have worked 7 hours 45 minutes'),
-    ).toBeVisible();
+    await expect(dialog.getByText('You have worked 7 hours 45 minutes')).toBeVisible();
 
     // Explanatory sub-text
     await expect(
@@ -250,12 +243,8 @@ test.describe('Shift-End Reminder', () => {
     await expect(dialog.getByText(/another reminder in 2 hours/)).toBeVisible();
 
     // Both action buttons (scoped to dialog to avoid matching notification row text)
-    await expect(
-      dialog.getByRole('button', { name: /Continue Working/i }),
-    ).toBeVisible();
-    await expect(
-      dialog.getByRole('button', { name: /Agree to.*clock out/i }),
-    ).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Continue Working/i })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Agree to.*clock out/i })).toBeVisible();
 
     // Close button in modal header
     await expect(dialog.getByRole('button', { name: /close/i })).toBeVisible();
@@ -276,7 +265,10 @@ test.describe('Shift-End Reminder', () => {
     await page.reload();
 
     // Open modal
-    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    await page
+      .getByRole('button', { name: /Shift End Reminder/ })
+      .first()
+      .click();
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
@@ -287,9 +279,9 @@ test.describe('Shift-End Reminder', () => {
     await expect(dialog).not.toBeVisible({ timeout: 8000 });
 
     // Notification removed from list
-    await expect(
-      page.getByRole('button', { name: /Shift End Reminder/ }),
-    ).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Shift End Reminder/ })).not.toBeVisible({
+      timeout: 5000,
+    });
 
     // ── Verify backend state ───────────────────────────────────────────────
     const clockRes = await page.request.get(`${API_BASE}/clock/active`, {
@@ -337,7 +329,10 @@ test.describe('Shift-End Reminder', () => {
     await page.reload();
 
     // Open modal
-    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    await page
+      .getByRole('button', { name: /Shift End Reminder/ })
+      .first()
+      .click();
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
 
@@ -348,9 +343,9 @@ test.describe('Shift-End Reminder', () => {
     await expect(dialog).not.toBeVisible({ timeout: 8000 });
 
     // Notification removed from list
-    await expect(
-      page.getByRole('button', { name: /Shift End Reminder/ }),
-    ).not.toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole('button', { name: /Shift End Reminder/ })).not.toBeVisible({
+      timeout: 5000,
+    });
 
     // ── Verify backend state ───────────────────────────────────────────────
     const clockRes = await page.request.get(`${API_BASE}/clock/active`, {
@@ -393,7 +388,10 @@ test.describe('Shift-End Reminder', () => {
     await page.reload();
 
     // Open modal and agree
-    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    await page
+      .getByRole('button', { name: /Shift End Reminder/ })
+      .first()
+      .click();
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
     await dialog.getByRole('button', { name: /Agree to.*clock out/i }).click();
@@ -431,7 +429,12 @@ test.describe('Shift-End Reminder', () => {
         event: { id: string } | null;
       };
       const { notifications } = (await notifPollRes.json()) as {
-        notifications: Array<{ id: string; title: string; body: string; data?: Record<string, unknown> }>;
+        notifications: Array<{
+          id: string;
+          title: string;
+          body: string;
+          data?: Record<string, unknown>;
+        }>;
       };
 
       const autoNotif = notifications.find((n) => n.data?.type === 'auto-clock-out');
@@ -457,9 +460,9 @@ test.describe('Shift-End Reminder', () => {
     await expect(autoNotifRow).toContainText('automatically clocked out as you agreed');
 
     // No lingering shift-end-reminder in the list
-    await expect(
-      page.getByRole('button', { name: /Shift End Reminder/ }),
-    ).not.toBeVisible({ timeout: 3000 });
+    await expect(page.getByRole('button', { name: /Shift End Reminder/ })).not.toBeVisible({
+      timeout: 3000,
+    });
   });
 
   // ── Test 5: global modal — appears on dashboard (not just notifications page) ──
@@ -511,7 +514,10 @@ test.describe('Shift-End Reminder', () => {
     await page.reload();
 
     // Open modal and choose Continue Working
-    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    await page
+      .getByRole('button', { name: /Shift End Reminder/ })
+      .first()
+      .click();
     const dialog = page.locator('[role="dialog"]');
     await expect(dialog).toBeVisible({ timeout: 5000 });
     await dialog.getByRole('button', { name: /Continue Working/i }).click();
@@ -563,7 +569,10 @@ test.describe('Shift-End Reminder', () => {
     const { event: finalEvent } = (await finalRes.json()) as {
       event: { workSeconds: number; shiftAutoClockoutWorkSecs: number | null } | null;
     };
-    expect(finalEvent, 'session must still be active past 8h after Continue Working').not.toBeNull();
+    expect(
+      finalEvent,
+      'session must still be active past 8h after Continue Working',
+    ).not.toBeNull();
     expect(finalEvent!.shiftAutoClockoutWorkSecs).toBeNull();
     expect(finalEvent!.workSeconds).toBeGreaterThan(28800); // past 8h
   });
@@ -669,7 +678,10 @@ test.describe('Shift-End Reminder', () => {
         headers: authHeaders(authToken),
       });
       const { event } = (await res.json()) as { event: unknown | null };
-      if (!event) { autoClockedOut = true; break; }
+      if (!event) {
+        autoClockedOut = true;
+        break;
+      }
     }
     expect(autoClockedOut, 'Carol should be auto-clocked out within 60s').toBe(true);
 
@@ -688,7 +700,10 @@ test.describe('Shift-End Reminder', () => {
 
     const adminNotif = aliceNotifs.find((n) => n.data?.type === 'auto-clock-out-admin');
 
-    expect(adminNotif, 'Alice (co-admin) should receive an auto-clock-out-admin notification').toBeTruthy();
+    expect(
+      adminNotif,
+      'Alice (co-admin) should receive an auto-clock-out-admin notification',
+    ).toBeTruthy();
     expect(adminNotif!.title).toBe('Auto Clocked Out');
     // Body should mention Carol agreed — NOT the "no response" wording
     expect(adminNotif!.body).toContain('Carol Dev');

--- a/e2e/shift-reminder.spec.ts
+++ b/e2e/shift-reminder.spec.ts
@@ -1,0 +1,336 @@
+/**
+ * Shift-End Reminder E2E Tests
+ *
+ * Tests the full shift-end reminder flow end-to-end:
+ *
+ *  Setup:
+ *    - Login as Carol Dev (carol@example.com)
+ *    - Clock in to get an active clock event
+ *    - Backdating startTime via PUT /clock/:id/times (endTime: null keeps event active)
+ *      to 7h 44m 30s ago — the ClockMonitorService fires every 30s, so Check B
+ *      (SEVEN_HOURS_45_MIN_SECONDS = 27900) will trigger within the next tick.
+ *
+ *  Tests:
+ *    1. Notification appears — verifies the modal shows with correct title, body,
+ *       explanatory subtext, "Continue Working" button, and "Agree to Clock Out" button.
+ *    2. "Continue Working" path — modal closes, notification removed, clock still active,
+ *       shiftNextReminderWorkSecs is scheduled 2h out.
+ *    3. "Agree to Clock Out" path — modal closes, notification removed, clock still active
+ *       (monitor will handle the eventual auto-clockout at 8h), shiftReminderResponse = agreed.
+ *
+ *  Polling strategy: after backdating, poll GET /v1/notifications every 5s up to 90s.
+ *  The monitor runs every 30s so the notification should appear within 35-65s.
+ *
+ *  NOTE: Carol is an admin of the "Developers" team in seed data, which means she can
+ *  edit her own clock event times and will also receive admin notifications when shift
+ *  reminders are ignored.
+ */
+
+import { expect, test } from '@playwright/test';
+
+const CAROL_EMAIL = 'carol@example.com';
+const CAROL_PASSWORD = 'Password1!';
+const API_BASE = 'http://localhost:4000/v1';
+
+// 7h 44m 30s — next monitor tick (≤30s) pushes workSeconds past 7h 45m = 27900s
+const BACKDATE_SECS = 7 * 3600 + 44 * 60 + 30;
+const POLL_INTERVAL_MS = 5000;
+const POLL_MAX_ATTEMPTS = 18; // 18 × 5s = 90s timeout
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+/** Login and return the session Bearer token from localStorage. */
+async function login(page: import('@playwright/test').Page): Promise<string> {
+  await page.goto('/app');
+  await page.waitForSelector('input[type="email"]', { timeout: 10000 });
+  await page.fill('input[type="email"]', CAROL_EMAIL);
+  await page.fill('input[type="password"]', CAROL_PASSWORD);
+  await page.getByRole('button', { name: 'Sign in' }).click();
+  await page.waitForURL('**/dashboard', { timeout: 15000 });
+  // The frontend stores the better-auth Bearer token in localStorage
+  const token = await page.evaluate(() => localStorage.getItem('timecore_session_token'));
+  return token ?? '';
+}
+
+function authHeaders(token: string) {
+  return { Authorization: `Bearer ${token}` };
+}
+
+async function ensureClockedOut(
+  page: import('@playwright/test').Page,
+  token: string,
+) {
+  const res = await page.request.get(`${API_BASE}/clock/active`, {
+    headers: authHeaders(token),
+  });
+  const body = (await res.json()) as { event: { teamId: string } | null };
+  if (!body.event) return;
+  await page.request.post(`${API_BASE}/clock/stop`, {
+    headers: authHeaders(token),
+    data: { teamId: body.event.teamId },
+  });
+}
+
+/** Delete any leftover shift-end-reminder notifications from prior test runs. */
+async function clearShiftReminderNotifications(
+  page: import('@playwright/test').Page,
+  token: string,
+) {
+  const res = await page.request.get(`${API_BASE}/notifications`, {
+    headers: authHeaders(token),
+  });
+  const { notifications } = (await res.json()) as {
+    notifications: Array<{ id: string; data?: Record<string, unknown> }>;
+  };
+  const ids = notifications
+    .filter((n) => n.data?.type === 'shift-end-reminder')
+    .map((n) => n.id);
+  if (ids.length === 0) return;
+  await page.request.delete(`${API_BASE}/notifications`, {
+    headers: authHeaders(token),
+    data: { ids },
+  });
+}
+
+async function clockIn(
+  page: import('@playwright/test').Page,
+  token: string,
+): Promise<{ eventId: string; teamId: string }> {
+  const teamsRes = await page.request.get(`${API_BASE}/teams`, {
+    headers: authHeaders(token),
+  });
+  const { teams } = (await teamsRes.json()) as { teams: { id: string }[] };
+  const teamId = teams[0].id;
+  const startRes = await page.request.post(`${API_BASE}/clock/start`, {
+    headers: authHeaders(token),
+    data: { teamId },
+  });
+  const { event } = (await startRes.json()) as { event: { id: string } };
+  return { eventId: event.id, teamId };
+}
+
+/** Backdate the clock event's startTime while keeping it active (endTime: null). */
+async function backdateEvent(
+  page: import('@playwright/test').Page,
+  token: string,
+  eventId: string,
+  backdateSecs: number,
+) {
+  const res = await page.request.put(`${API_BASE}/clock/${eventId}/times`, {
+    headers: authHeaders(token),
+    data: {
+      startTime: Date.now() - backdateSecs * 1000,
+      endTime: null,
+    },
+  });
+  expect(res.ok(), `backdateEvent failed: ${await res.text()}`).toBe(true);
+}
+
+/** Poll notifications until a shift-end-reminder appears or timeout. */
+async function waitForShiftReminder(
+  page: import('@playwright/test').Page,
+  token: string,
+): Promise<boolean> {
+  for (let i = 0; i < POLL_MAX_ATTEMPTS; i++) {
+    await page.waitForTimeout(POLL_INTERVAL_MS);
+    const res = await page.request.get(`${API_BASE}/notifications`, {
+      headers: authHeaders(token),
+    });
+    const { notifications } = (await res.json()) as {
+      notifications: Array<{ data?: Record<string, unknown> }>;
+    };
+    if (notifications.some((n) => n.data?.type === 'shift-end-reminder')) return true;
+  }
+  return false;
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Shift-End Reminder', () => {
+  test.describe.configure({ mode: 'serial' });
+
+  // 3 min: up to 90s polling + UI interaction + buffer
+  test.setTimeout(180_000);
+
+  let authToken = '';
+
+  test.beforeEach(async ({ page }) => {
+    authToken = await login(page);
+    await ensureClockedOut(page, authToken);
+    await clearShiftReminderNotifications(page, authToken);
+  });
+
+  test.afterEach(async ({ page }) => {
+    await ensureClockedOut(page, authToken);
+  });
+
+  // ── Test 1: notification appears + modal content ───────────────────────────
+
+  test('shift-end reminder notification appears within 90s of reaching 7h 45m', async ({
+    page,
+  }) => {
+    // Clock in and backdate to just before the 7h 45m threshold
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    // Navigate to notifications page while we poll
+    await page.goto('/app/notifications');
+
+    // Wait for the monitor to fire
+    const found = await waitForShiftReminder(page, authToken);
+    expect(found, 'shift-end-reminder notification should appear within 90s').toBe(true);
+
+    // Reload to pick up the new notification
+    await page.reload();
+
+    // ── Notification row ───────────────────────────────────────────────────
+    const notifRow = page.getByRole('button', { name: /Shift End Reminder/ }).first();
+    await expect(notifRow).toBeVisible({ timeout: 10000 });
+    await expect(notifRow).toContainText('You have worked 7 hours 45 minutes');
+
+    // ── Click to open modal ────────────────────────────────────────────────
+    await notifRow.click();
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Title
+    await expect(dialog.getByRole('heading', { name: 'Shift End Reminder' })).toBeVisible();
+
+    // Body — the notification message
+    await expect(
+      dialog.getByText('You have worked 7 hours 45 minutes'),
+    ).toBeVisible();
+
+    // Explanatory sub-text
+    await expect(
+      dialog.getByText(/Agreeing will automatically clock you out when you reach 8 hours/),
+    ).toBeVisible();
+    await expect(dialog.getByText(/another reminder in 2 hours/)).toBeVisible();
+
+    // Both action buttons (scoped to dialog to avoid matching notification row text)
+    await expect(
+      dialog.getByRole('button', { name: /Continue Working/i }),
+    ).toBeVisible();
+    await expect(
+      dialog.getByRole('button', { name: /Agree to.*clock out/i }),
+    ).toBeVisible();
+
+    // Close button in modal header
+    await expect(dialog.getByRole('button', { name: /close/i })).toBeVisible();
+  });
+
+  // ── Test 2: "Continue Working" (disagree) path ────────────────────────────
+
+  test('"Continue Working" closes modal, removes notification, schedules 2h reminder', async ({
+    page,
+  }) => {
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    await page.goto('/app/notifications');
+    const found = await waitForShiftReminder(page, authToken);
+    expect(found, 'shift-end-reminder notification should appear within 90s').toBe(true);
+
+    await page.reload();
+
+    // Open modal
+    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Click "Continue Working"
+    await dialog.getByRole('button', { name: /Continue Working/i }).click();
+
+    // Modal should close
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Notification removed from list
+    await expect(
+      page.getByRole('button', { name: /Shift End Reminder/ }),
+    ).not.toBeVisible({ timeout: 5000 });
+
+    // ── Verify backend state ───────────────────────────────────────────────
+    const clockRes = await page.request.get(`${API_BASE}/clock/active`, {
+      headers: authHeaders(authToken),
+    });
+    const { event } = (await clockRes.json()) as {
+      event: {
+        id: string;
+        workSeconds: number;
+        shiftReminderResponse?: string;
+        shiftNextReminderWorkSecs?: number | null;
+        shiftAutoClockoutWorkSecs?: number | null;
+      } | null;
+    };
+
+    // Clock session still active (not clocked out)
+    expect(event, 'clock session should still be active after Continue Working').not.toBeNull();
+    expect(event!.id).toBe(eventId);
+
+    // Response recorded as disagreed
+    expect(event!.shiftReminderResponse).toBe('disagreed');
+
+    // Auto-clockout threshold cleared
+    expect(event!.shiftAutoClockoutWorkSecs).toBeNull();
+
+    // Next reminder scheduled ~2h out from current work time
+    expect(event!.shiftNextReminderWorkSecs).toBeGreaterThan(0);
+    // Should be roughly currentWorkSecs + 2h (7200s); we know work is ~7h45m = 27900s
+    const expectedMin = 27900 + 7200 - 120; // slight tolerance
+    expect(event!.shiftNextReminderWorkSecs).toBeGreaterThan(expectedMin);
+  });
+
+  // ── Test 3: "Agree to Clock Out" path ────────────────────────────────────
+
+  test('"Agree to Clock Out" closes modal, removes notification, records agreed response', async ({
+    page,
+  }) => {
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    await page.goto('/app/notifications');
+    const found = await waitForShiftReminder(page, authToken);
+    expect(found, 'shift-end-reminder notification should appear within 90s').toBe(true);
+
+    await page.reload();
+
+    // Open modal
+    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // Click "Agree to Clock Out"
+    await dialog.getByRole('button', { name: /Agree to.*clock out/i }).click();
+
+    // Modal should close
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Notification removed from list
+    await expect(
+      page.getByRole('button', { name: /Shift End Reminder/ }),
+    ).not.toBeVisible({ timeout: 5000 });
+
+    // ── Verify backend state ───────────────────────────────────────────────
+    const clockRes = await page.request.get(`${API_BASE}/clock/active`, {
+      headers: authHeaders(authToken),
+    });
+    const { event } = (await clockRes.json()) as {
+      event: {
+        id: string;
+        shiftReminderResponse?: string;
+        shiftAutoClockoutWorkSecs?: number | null;
+      } | null;
+    };
+
+    // Session still active — monitor handles the eventual clockout at 8h
+    expect(event, 'clock session should still be active — monitor clocks out at 8h').not.toBeNull();
+    expect(event!.id).toBe(eventId);
+
+    // Response recorded as agreed
+    expect(event!.shiftReminderResponse).toBe('agreed');
+
+    // Auto-clockout threshold still armed at 28800 (8h)
+    expect(event!.shiftAutoClockoutWorkSecs).toBe(28800);
+  });
+});

--- a/e2e/shift-reminder.spec.ts
+++ b/e2e/shift-reminder.spec.ts
@@ -30,6 +30,9 @@ import { expect, test } from '@playwright/test';
 
 const CAROL_EMAIL = 'carol@example.com';
 const CAROL_PASSWORD = 'Password1!';
+// Alice is a co-admin of Carol's "Developers" team in seed data
+const ALICE_EMAIL = 'alice@example.com';
+const ALICE_PASSWORD = 'Password1!';
 const API_BASE = 'http://localhost:4000/v1';
 
 // 7h 44m 30s — next monitor tick (≤30s) pushes workSeconds past 7h 45m = 27900s
@@ -56,6 +59,38 @@ function authHeaders(token: string) {
   return { Authorization: `Bearer ${token}` };
 }
 
+/**
+ * Login via the better-auth API directly using native fetch (NOT page.request).
+ *
+ * IMPORTANT: Do NOT use page.request here. page.request shares the browser's
+ * cookie jar, so signing in as Alice would set Alice's session cookie in the
+ * browser. That contaminated cookie would then override Carol's Bearer-token
+ * auth on subsequent requests made by the app (e.g. /v1/me on page load),
+ * causing useSession() to return null and breaking the ShiftReminderContext WS.
+ *
+ * Using the Node.js global fetch keeps the HTTP request completely isolated
+ * from the browser's storage state.
+ */
+async function loginViaApi(
+  _page: import('@playwright/test').Page,
+  email: string,
+  password: string,
+): Promise<string> {
+  const res = await fetch('http://localhost:4000/api/auth/sign-in/email', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      // better-auth's CSRF protection requires a trusted Origin header.
+      // Browser requests include this automatically; Node.js fetch does not.
+      'Origin': 'http://localhost:3000',
+    },
+    body: JSON.stringify({ email, password }),
+  });
+  const body = (await res.json()) as { token?: string };
+  if (!res.ok || !body.token) throw new Error(`loginViaApi failed for ${email}: ${res.status}`);
+  return body.token;
+}
+
 async function ensureClockedOut(
   page: import('@playwright/test').Page,
   token: string,
@@ -71,7 +106,7 @@ async function ensureClockedOut(
   });
 }
 
-/** Delete any leftover shift-end-reminder notifications from prior test runs. */
+/** Delete leftover shift-end-reminder and auto-clock-out notifications from prior runs. */
 async function clearShiftReminderNotifications(
   page: import('@playwright/test').Page,
   token: string,
@@ -83,7 +118,9 @@ async function clearShiftReminderNotifications(
     notifications: Array<{ id: string; data?: Record<string, unknown> }>;
   };
   const ids = notifications
-    .filter((n) => n.data?.type === 'shift-end-reminder')
+    .filter((n) =>
+      n.data?.type === 'shift-end-reminder' || n.data?.type === 'auto-clock-out',
+    )
     .map((n) => n.id);
   if (ids.length === 0) return;
   await page.request.delete(`${API_BASE}/notifications`, {
@@ -95,12 +132,15 @@ async function clearShiftReminderNotifications(
 async function clockIn(
   page: import('@playwright/test').Page,
   token: string,
+  teamId?: string,
 ): Promise<{ eventId: string; teamId: string }> {
-  const teamsRes = await page.request.get(`${API_BASE}/teams`, {
-    headers: authHeaders(token),
-  });
-  const { teams } = (await teamsRes.json()) as { teams: { id: string }[] };
-  const teamId = teams[0].id;
+  if (!teamId) {
+    const teamsRes = await page.request.get(`${API_BASE}/teams`, {
+      headers: authHeaders(token),
+    });
+    const { teams } = (await teamsRes.json()) as { teams: { id: string }[] };
+    teamId = teams[0].id;
+  }
   const startRes = await page.request.post(`${API_BASE}/clock/start`, {
     headers: authHeaders(token),
     data: { teamId },
@@ -332,5 +372,331 @@ test.describe('Shift-End Reminder', () => {
 
     // Auto-clockout threshold still armed at 28800 (8h)
     expect(event!.shiftAutoClockoutWorkSecs).toBe(28800);
+  });
+
+  // ── Test 4: agree → monitor auto-clocks out + sends "Auto Clocked Out" notification ───
+
+  test('"Agree to Clock Out" triggers auto-clockout at 8h and sends Auto Clocked Out notification', async ({
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    // Clock in and backdate to just before 7h 45m to trigger reminder
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    await page.goto('/app/notifications');
+    const found = await waitForShiftReminder(page, authToken);
+    expect(found, 'shift-end-reminder notification should appear within 90s').toBe(true);
+
+    await page.reload();
+
+    // Open modal and agree
+    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole('button', { name: /Agree to.*clock out/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Verify agreed state
+    const clockRes1 = await page.request.get(`${API_BASE}/clock/active`, {
+      headers: authHeaders(authToken),
+    });
+    const { event: agreedEvent } = (await clockRes1.json()) as {
+      event: {
+        id: string;
+        shiftReminderResponse?: string;
+        shiftAutoClockoutWorkSecs?: number | null;
+      } | null;
+    };
+    expect(agreedEvent, 'event should still be active after agreeing').not.toBeNull();
+    expect(agreedEvent!.shiftReminderResponse).toBe('agreed');
+    expect(agreedEvent!.shiftAutoClockoutWorkSecs).toBe(28800);
+
+    // Backdate to 8h 01m so monitor fires Check C (workSeconds ≥ shiftAutoClockoutWorkSecs)
+    await backdateEvent(page, authToken, eventId, 8 * 3600 + 60);
+
+    // Poll up to 60s for the auto-clockout + "Auto Clocked Out" notification
+    let autoClockedOut = false;
+    let autoNotifBody = '';
+    for (let i = 0; i < 12; i++) {
+      await page.waitForTimeout(5000);
+
+      const [clockPollRes, notifPollRes] = await Promise.all([
+        page.request.get(`${API_BASE}/clock/active`, { headers: authHeaders(authToken) }),
+        page.request.get(`${API_BASE}/notifications`, { headers: authHeaders(authToken) }),
+      ]);
+      const { event: pollEvent } = (await clockPollRes.json()) as {
+        event: { id: string } | null;
+      };
+      const { notifications } = (await notifPollRes.json()) as {
+        notifications: Array<{ id: string; title: string; body: string; data?: Record<string, unknown> }>;
+      };
+
+      const autoNotif = notifications.find((n) => n.data?.type === 'auto-clock-out');
+      if (!pollEvent && autoNotif) {
+        autoClockedOut = true;
+        autoNotifBody = autoNotif.body;
+        break;
+      }
+    }
+
+    expect(autoClockedOut, 'monitor should auto-clock-out and send notification within 60s').toBe(
+      true,
+    );
+
+    // Notification body should acknowledge the user agreed
+    expect(autoNotifBody).toContain('automatically clocked out as you agreed');
+
+    // ── Verify in UI ───────────────────────────────────────────────────────
+    await page.reload();
+
+    const autoNotifRow = page.getByRole('button', { name: /Auto Clocked Out/ }).first();
+    await expect(autoNotifRow).toBeVisible({ timeout: 5000 });
+    await expect(autoNotifRow).toContainText('automatically clocked out as you agreed');
+
+    // No lingering shift-end-reminder in the list
+    await expect(
+      page.getByRole('button', { name: /Shift End Reminder/ }),
+    ).not.toBeVisible({ timeout: 3000 });
+  });
+
+  // ── Test 5: global modal — appears on dashboard (not just notifications page) ──
+
+  test('shift-end reminder modal pops up automatically on dashboard via global WebSocket', async ({
+    page,
+  }) => {
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    // Navigate to the dashboard — NOT the notifications page.
+    // The global ShiftReminderProvider opens a WebSocket stream that auto-opens
+    // the modal on any page when a shift-end-reminder arrives.
+    await page.goto('/app/dashboard');
+
+    // The modal should pop up automatically within 90s (monitor fires every 30s)
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 90_000 });
+
+    // Verify it is the shift reminder modal
+    await expect(dialog.getByRole('heading', { name: 'Shift End Reminder' })).toBeVisible();
+    await expect(dialog.getByText(/You have worked 7 hours 45 minutes/)).toBeVisible();
+    await expect(dialog.getByText(/Agreeing will automatically clock you out/)).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Continue Working/i })).toBeVisible();
+    await expect(dialog.getByRole('button', { name: /Agree to.*clock out/i })).toBeVisible();
+
+    // Dismiss via "Continue Working" — we never navigated to notifications
+    await dialog.getByRole('button', { name: /Continue Working/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Confirm the user remained on the dashboard throughout
+    expect(page.url()).toContain('/app/dashboard');
+  });
+
+  // ── Test 6: "Continue Working" DISARMS auto-clockout — stays active past 8h ──
+
+  test('"Continue Working" disarms auto-clockout — session stays active past 8 hours', async ({
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    const { eventId } = await clockIn(page, authToken);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    await page.goto('/app/notifications');
+    const found = await waitForShiftReminder(page, authToken);
+    expect(found, 'shift-end-reminder notification should appear within 90s').toBe(true);
+
+    await page.reload();
+
+    // Open modal and choose Continue Working
+    await page.getByRole('button', { name: /Shift End Reminder/ }).first().click();
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+    await dialog.getByRole('button', { name: /Continue Working/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Verify auto-clockout is disarmed
+    const clockRes1 = await page.request.get(`${API_BASE}/clock/active`, {
+      headers: authHeaders(authToken),
+    });
+    const { event: disagreedEvent } = (await clockRes1.json()) as {
+      event: {
+        id: string;
+        shiftReminderResponse?: string;
+        shiftAutoClockoutWorkSecs?: number | null;
+        shiftNextReminderWorkSecs?: number | null;
+      } | null;
+    };
+    expect(disagreedEvent, 'session should still be active').not.toBeNull();
+    expect(disagreedEvent!.shiftReminderResponse).toBe('disagreed');
+    expect(disagreedEvent!.shiftAutoClockoutWorkSecs).toBeNull(); // disarmed
+    expect(disagreedEvent!.shiftNextReminderWorkSecs).toBeGreaterThan(0); // 2h repeat armed
+
+    // Backdate past 8h — the monitor should NOT clock out
+    await backdateEvent(page, authToken, eventId, 8 * 3600 + 60);
+
+    // Poll for 45s — if the monitor fires, it must NOT clock out
+    let clockedOutUnexpectedly = false;
+    for (let i = 0; i < 9; i++) {
+      await page.waitForTimeout(5000);
+      const pollRes = await page.request.get(`${API_BASE}/clock/active`, {
+        headers: authHeaders(authToken),
+      });
+      const { event: pollEvent } = (await pollRes.json()) as { event: { id: string } | null };
+      if (!pollEvent) {
+        clockedOutUnexpectedly = true;
+        break;
+      }
+    }
+
+    expect(
+      clockedOutUnexpectedly,
+      '"Continue Working" should NOT trigger auto-clockout at 8h — auto-clockout was disarmed',
+    ).toBe(false);
+
+    // Final confirmation: session is still running
+    const finalRes = await page.request.get(`${API_BASE}/clock/active`, {
+      headers: authHeaders(authToken),
+    });
+    const { event: finalEvent } = (await finalRes.json()) as {
+      event: { workSeconds: number; shiftAutoClockoutWorkSecs: number | null } | null;
+    };
+    expect(finalEvent, 'session must still be active past 8h after Continue Working').not.toBeNull();
+    expect(finalEvent!.shiftAutoClockoutWorkSecs).toBeNull();
+    expect(finalEvent!.workSeconds).toBeGreaterThan(28800); // past 8h
+  });
+
+  // ── Test 7: admin receives notification when user agrees and is auto-clocked out ──
+
+  test('admin receives auto-clock-out notification when user agrees and is clocked out at 8h', async ({
+    page,
+  }) => {
+    test.setTimeout(240_000);
+
+    // ── Cleanup: delete any leftover test teams from prior failed runs ───────
+    const carolTeamsRes = await page.request.get(`${API_BASE}/teams`, {
+      headers: authHeaders(authToken),
+    });
+    const { teams: carolTeams } = (await carolTeamsRes.json()) as {
+      teams: { id: string; name: string }[];
+    };
+    for (const t of carolTeams) {
+      if (t.name === 'e2e-admin-notif-test') {
+        await page.request.delete(`${API_BASE}/teams/${t.id}`, {
+          headers: authHeaders(authToken),
+        });
+      }
+    }
+
+    // ── Setup: create a shared team with Alice as co-admin ──────────────────
+    const createTeamRes = await page.request.post(`${API_BASE}/teams`, {
+      headers: authHeaders(authToken),
+      data: { name: 'e2e-admin-notif-test' },
+    });
+    expect(createTeamRes.ok(), 'create shared team failed').toBe(true);
+    const { team: sharedTeam } = (await createTeamRes.json()) as { team: { id: string } };
+    const sharedTeamId = sharedTeam.id;
+
+    // Invite Alice directly (adds her as a member)
+    const inviteRes = await page.request.post(`${API_BASE}/teams/${sharedTeamId}/invite`, {
+      headers: authHeaders(authToken),
+      data: { email: ALICE_EMAIL },
+    });
+    expect(inviteRes.ok(), 'invite Alice failed').toBe(true);
+
+    // Find Alice's userId from the members list
+    const membersRes = await page.request.get(`${API_BASE}/teams/${sharedTeamId}/members`, {
+      headers: authHeaders(authToken),
+    });
+    const { members } = (await membersRes.json()) as {
+      members: Array<{ id: string; email: string }>;
+    };
+    const aliceMember = members.find((m) => m.email === ALICE_EMAIL);
+    expect(aliceMember, 'Alice should appear in team members').toBeTruthy();
+
+    // Promote Alice to admin
+    const roleRes = await page.request.put(
+      `${API_BASE}/teams/${sharedTeamId}/members/${aliceMember!.id}/role`,
+      { headers: authHeaders(authToken), data: { role: 'admin' } },
+    );
+    expect(roleRes.ok(), 'promote Alice to admin failed').toBe(true);
+
+    // Clear any stale auto-clock-out-admin notifications from Alice's inbox
+    const aliceToken = await loginViaApi(page, ALICE_EMAIL, ALICE_PASSWORD);
+    const aliceStaleRes = await page.request.get(`${API_BASE}/notifications`, {
+      headers: authHeaders(aliceToken),
+    });
+    const { notifications: aliceStale } = (await aliceStaleRes.json()) as {
+      notifications: Array<{ id: string; data?: Record<string, unknown> }>;
+    };
+    const staleIds = aliceStale
+      .filter((n) => n.data?.type === 'auto-clock-out-admin')
+      .map((n) => n.id);
+    if (staleIds.length > 0) {
+      await page.request.delete(`${API_BASE}/notifications`, {
+        headers: authHeaders(aliceToken),
+        data: { ids: staleIds },
+      });
+    }
+
+    // Clock Carol into the shared team (not her default Personal team)
+    const { eventId } = await clockIn(page, authToken, sharedTeamId);
+    await backdateEvent(page, authToken, eventId, BACKDATE_SECS);
+
+    // ── Navigate to dashboard and wait for the global modal ─────────────────
+    // ShiftReminderProvider opens a WebSocket on any page and auto-opens the
+    // modal when a shift-end-reminder arrives — no need to click a list button.
+    await page.goto('/app/dashboard');
+
+    const dialog = page.locator('[role="dialog"]');
+    await expect(dialog).toBeVisible({ timeout: 90_000 });
+    await expect(dialog.getByRole('heading', { name: 'Shift End Reminder' })).toBeVisible();
+
+    // Agree to clock out via the global modal
+    await dialog.getByRole('button', { name: /Agree to.*clock out/i }).click();
+    await expect(dialog).not.toBeVisible({ timeout: 8000 });
+
+    // Backdate past 8h so monitor triggers auto-clockout
+    await backdateEvent(page, authToken, eventId, 8 * 3600 + 60);
+
+    // Poll until Carol is clocked out (confirms Check C ran)
+    let autoClockedOut = false;
+    for (let i = 0; i < 12; i++) {
+      await page.waitForTimeout(5000);
+      const res = await page.request.get(`${API_BASE}/clock/active`, {
+        headers: authHeaders(authToken),
+      });
+      const { event } = (await res.json()) as { event: unknown | null };
+      if (!event) { autoClockedOut = true; break; }
+    }
+    expect(autoClockedOut, 'Carol should be auto-clocked out within 60s').toBe(true);
+
+    // ── Verify Alice (co-admin) received an admin notification ─────────────
+    // (aliceToken already obtained above for stale-notification cleanup)
+
+    // Give the notification a moment to persist
+    await page.waitForTimeout(2000);
+
+    const aliceNotifRes = await page.request.get(`${API_BASE}/notifications`, {
+      headers: authHeaders(aliceToken),
+    });
+    const { notifications: aliceNotifs } = (await aliceNotifRes.json()) as {
+      notifications: Array<{ title: string; body: string; data?: Record<string, unknown> }>;
+    };
+
+    const adminNotif = aliceNotifs.find((n) => n.data?.type === 'auto-clock-out-admin');
+
+    expect(adminNotif, 'Alice (co-admin) should receive an auto-clock-out-admin notification').toBeTruthy();
+    expect(adminNotif!.title).toBe('Auto Clocked Out');
+    // Body should mention Carol agreed — NOT the "no response" wording
+    expect(adminNotif!.body).toContain('Carol Dev');
+    expect(adminNotif!.body).toContain('after agreeing to the shift-end reminder');
+    expect(adminNotif!.body).not.toContain('no response');
+
+    // ── Cleanup: delete the shared team ─────────────────────────────────────
+    await page.request.delete(`${API_BASE}/teams/${sharedTeamId}`, {
+      headers: authHeaders(authToken),
+    });
   });
 });

--- a/e2e/shift-reminder.spec.ts
+++ b/e2e/shift-reminder.spec.ts
@@ -52,7 +52,8 @@ async function login(page: import('@playwright/test').Page): Promise<string> {
   await page.waitForURL('**/dashboard', { timeout: 15000 });
   // The frontend stores the better-auth Bearer token in localStorage
   const token = await page.evaluate(() => localStorage.getItem('timecore_session_token'));
-  return token ?? '';
+  if (!token) throw new Error('Expected timecore_session_token in localStorage after login');
+  return token;
 }
 
 function authHeaders(token: string) {

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -185,7 +185,7 @@ export const NotificationsPage: React.FC = () => {
         /* ignore */
       }
     },
-    [selectMode, toggleSelect, navigate],
+    [selectMode, toggleSelect, navigate, openShiftReminderModal],
   );
 
   const handleMarkAllRead = useCallback(async () => {

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -476,7 +476,6 @@ export const NotificationsPage: React.FC = () => {
           </Button>
         </ModalFooter>
       </Modal>
-
     </AppPage>
   );
 };

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -23,6 +23,7 @@ import { useSession } from '../../lib/useSession';
 import { useRouter } from '../../ui/router';
 import { AppPage } from '../../ui/AppPage';
 import { useRefresh } from '../../lib/RefreshContext';
+import { useShiftReminder } from './ShiftReminderContext';
 
 function timeAgo(date: Date | string | undefined): string {
   if (!date) return '';
@@ -92,8 +93,7 @@ export const NotificationsPage: React.FC = () => {
   const [markAllLoading, setMarkAllLoading] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [respondLoading, setRespondLoading] = useState(false);
-  const [shiftReminderNotif, setShiftReminderNotif] = useState<Notification | null>(null);
-  const [shiftRespondError, setShiftRespondError] = useState<string | null>(null);
+  const { openModal: openShiftReminderModal } = useShiftReminder();
 
   // Fetch inbox + open SSE for real-time delivery
   useEffect(() => {
@@ -117,6 +117,16 @@ export const NotificationsPage: React.FC = () => {
     };
     return () => es.close();
   }, [user]);
+
+  // Remove notifications handled by the global ShiftReminderModal
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const { id } = (e as CustomEvent<{ id: string }>).detail;
+      setNotifications((prev) => prev.filter((n) => n.id !== id));
+    };
+    window.addEventListener('timehuddle:shiftReminderHandled', handler);
+    return () => window.removeEventListener('timehuddle:shiftReminderHandled', handler);
+  }, []);
 
   useRefresh(
     React.useCallback(async () => {
@@ -165,8 +175,7 @@ export const NotificationsPage: React.FC = () => {
         if (data.type === 'shift-end-reminder') {
           await notificationApi.markOneRead(doc.id);
           setNotifications((prev) => prev.map((n) => (n.id === doc.id ? { ...n, read: true } : n)));
-          setShiftReminderNotif(doc);
-          setShiftRespondError(null);
+          openShiftReminderModal(doc);
           return;
         }
         await notificationApi.markOneRead(doc.id);
@@ -213,28 +222,6 @@ export const NotificationsPage: React.FC = () => {
     setInvitePreview(null);
     setInviteError(null);
   }, []);
-
-  const closeShiftReminderModal = useCallback(() => {
-    setShiftReminderNotif(null);
-    setShiftRespondError(null);
-  }, []);
-
-  const handleShiftReminderAction = useCallback(
-    async (action: 'agree' | 'disagree') => {
-      if (!shiftReminderNotif) return;
-      setRespondLoading(true);
-      try {
-        await notificationApi.respondToShiftReminder(shiftReminderNotif.id, action);
-        setNotifications((prev) => prev.filter((n) => n.id !== shiftReminderNotif.id));
-        closeShiftReminderModal();
-      } catch (e: any) {
-        setShiftRespondError(e?.message || 'Failed to process response');
-      } finally {
-        setRespondLoading(false);
-      }
-    },
-    [shiftReminderNotif, closeShiftReminderModal],
-  );
 
   const handleInviteAction = useCallback(
     async (action: 'join' | 'ignore') => {
@@ -490,48 +477,6 @@ export const NotificationsPage: React.FC = () => {
         </ModalFooter>
       </Modal>
 
-      <Modal
-        open={!!shiftReminderNotif}
-        onOpenChange={(open) => !open && closeShiftReminderModal()}
-        size="lg"
-      >
-        <ModalHeader>
-          <ModalTitle>Shift End Reminder</ModalTitle>
-          <ModalClose />
-        </ModalHeader>
-        <ModalBody>
-          <div className="space-y-3">
-            <Text size="sm">{shiftReminderNotif?.body}</Text>
-            <Text size="sm" variant="muted">
-              Agreeing will automatically clock you out when you reach 8 hours of work time.
-              Choosing &ldquo;Continue Working&rdquo; will send another reminder in 2 hours.
-            </Text>
-            {shiftRespondError && (
-              <Text size="sm" variant="destructive">
-                {shiftRespondError}
-              </Text>
-            )}
-          </div>
-        </ModalBody>
-        <ModalFooter>
-          <Button
-            variant="outline"
-            onClick={() => handleShiftReminderAction('disagree')}
-            isLoading={respondLoading}
-            aria-label="Continue working — reminder in 2 hours"
-          >
-            Continue Working
-          </Button>
-          <Button
-            variant="primary"
-            onClick={() => handleShiftReminderAction('agree')}
-            isLoading={respondLoading}
-            aria-label="Agree to auto clock out at 8 hours"
-          >
-            Agree to Clock Out
-          </Button>
-        </ModalFooter>
-      </Modal>
     </AppPage>
   );
 };

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -92,6 +92,8 @@ export const NotificationsPage: React.FC = () => {
   const [markAllLoading, setMarkAllLoading] = useState(false);
   const [deleteLoading, setDeleteLoading] = useState(false);
   const [respondLoading, setRespondLoading] = useState(false);
+  const [shiftReminderNotif, setShiftReminderNotif] = useState<Notification | null>(null);
+  const [shiftRespondError, setShiftRespondError] = useState<string | null>(null);
 
   // Fetch inbox + open SSE for real-time delivery
   useEffect(() => {
@@ -160,6 +162,13 @@ export const NotificationsPage: React.FC = () => {
           setInviteError(null);
           return;
         }
+        if (data.type === 'shift-end-reminder') {
+          await notificationApi.markOneRead(doc.id);
+          setNotifications((prev) => prev.map((n) => (n.id === doc.id ? { ...n, read: true } : n)));
+          setShiftReminderNotif(doc);
+          setShiftRespondError(null);
+          return;
+        }
         await notificationApi.markOneRead(doc.id);
         setNotifications((prev) => prev.map((n) => (n.id === doc.id ? { ...n, read: true } : n)));
         resolveNotificationTarget(doc, navigate);
@@ -204,6 +213,28 @@ export const NotificationsPage: React.FC = () => {
     setInvitePreview(null);
     setInviteError(null);
   }, []);
+
+  const closeShiftReminderModal = useCallback(() => {
+    setShiftReminderNotif(null);
+    setShiftRespondError(null);
+  }, []);
+
+  const handleShiftReminderAction = useCallback(
+    async (action: 'agree' | 'disagree') => {
+      if (!shiftReminderNotif) return;
+      setRespondLoading(true);
+      try {
+        await notificationApi.respondToShiftReminder(shiftReminderNotif.id, action);
+        setNotifications((prev) => prev.filter((n) => n.id !== shiftReminderNotif.id));
+        closeShiftReminderModal();
+      } catch (e: any) {
+        setShiftRespondError(e?.message || 'Failed to process response');
+      } finally {
+        setRespondLoading(false);
+      }
+    },
+    [shiftReminderNotif, closeShiftReminderModal],
+  );
 
   const handleInviteAction = useCallback(
     async (action: 'join' | 'ignore') => {
@@ -455,6 +486,49 @@ export const NotificationsPage: React.FC = () => {
             disabled={invitePreview?.alreadyMember}
           >
             {invitePreview?.alreadyMember ? 'Already in team' : 'Join'}
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      <Modal
+        open={!!shiftReminderNotif}
+        onOpenChange={(open) => !open && closeShiftReminderModal()}
+        size="lg"
+      >
+        <ModalHeader>
+          <ModalTitle>Shift End Reminder</ModalTitle>
+          <ModalClose />
+        </ModalHeader>
+        <ModalBody>
+          <div className="space-y-3">
+            <Text size="sm">{shiftReminderNotif?.body}</Text>
+            <Text size="sm" variant="muted">
+              Agreeing will automatically clock you out when you reach 8 hours of work time.
+              Choosing &ldquo;Continue Working&rdquo; will send another reminder in 2 hours.
+            </Text>
+            {shiftRespondError && (
+              <Text size="sm" variant="destructive">
+                {shiftRespondError}
+              </Text>
+            )}
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleShiftReminderAction('disagree')}
+            isLoading={respondLoading}
+            aria-label="Continue working — reminder in 2 hours"
+          >
+            Continue Working
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => handleShiftReminderAction('agree')}
+            isLoading={respondLoading}
+            aria-label="Agree to auto clock out at 8 hours"
+          >
+            Agree to Clock Out
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/features/notifications/ShiftReminderContext.tsx
+++ b/src/features/notifications/ShiftReminderContext.tsx
@@ -61,10 +61,7 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
     ws.onmessage = (e) => {
       try {
         const n = JSON.parse(e.data) as Notification;
-        if (
-          n.data?.type === 'shift-end-reminder' &&
-          !shownIds.current.has(n.id)
-        ) {
+        if (n.data?.type === 'shift-end-reminder' && !shownIds.current.has(n.id)) {
           shownIds.current.add(n.id);
           setPendingNotif(n);
           setRespondError(null);
@@ -101,9 +98,7 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
           }),
         );
       } catch (err: unknown) {
-        setRespondError(
-          err instanceof Error ? err.message : 'Failed to process response',
-        );
+        setRespondError(err instanceof Error ? err.message : 'Failed to process response');
       } finally {
         setRespondLoading(false);
       }
@@ -115,11 +110,7 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
     <ShiftReminderContext.Provider value={{ openModal, closeModal }}>
       {children}
 
-      <Modal
-        open={!!pendingNotif}
-        onOpenChange={(open) => !open && closeModal()}
-        size="lg"
-      >
+      <Modal open={!!pendingNotif} onOpenChange={(open) => !open && closeModal()} size="lg">
         <ModalHeader>
           <ModalTitle>Shift End Reminder</ModalTitle>
           <ModalClose />
@@ -128,9 +119,8 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
           <div className="space-y-3">
             <Text size="sm">{pendingNotif?.body}</Text>
             <Text size="sm" variant="muted">
-              Agreeing will automatically clock you out when you reach the auto-clockout
-              threshold. Choosing &ldquo;Continue Working&rdquo; will send another reminder in
-              2 hours.
+              Agreeing will automatically clock you out when you reach the auto-clockout threshold.
+              Choosing &ldquo;Continue Working&rdquo; will send another reminder in 2 hours.
             </Text>
             {respondError && (
               <Text size="sm" variant="destructive">

--- a/src/features/notifications/ShiftReminderContext.tsx
+++ b/src/features/notifications/ShiftReminderContext.tsx
@@ -128,8 +128,8 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
           <div className="space-y-3">
             <Text size="sm">{pendingNotif?.body}</Text>
             <Text size="sm" variant="muted">
-              Agreeing will automatically clock you out when you reach 8 hours of work
-              time. Choosing &ldquo;Continue Working&rdquo; will send another reminder in
+              Agreeing will automatically clock you out when you reach the auto-clockout
+              threshold. Choosing &ldquo;Continue Working&rdquo; will send another reminder in
               2 hours.
             </Text>
             {respondError && (

--- a/src/features/notifications/ShiftReminderContext.tsx
+++ b/src/features/notifications/ShiftReminderContext.tsx
@@ -1,0 +1,163 @@
+/**
+ * ShiftReminderContext — global provider for the shift-end reminder modal.
+ *
+ * Mounts once in AppLayoutContent so the modal is reachable from every page.
+ * When a `shift-end-reminder` notification arrives via the WebSocket stream the
+ * modal pops up automatically, regardless of which page the user is on.
+ *
+ * NotificationsPage uses `useShiftReminder().openModal(notif)` when the user
+ * manually taps an existing reminder row in the inbox.
+ */
+import {
+  Button,
+  Modal,
+  ModalBody,
+  ModalClose,
+  ModalFooter,
+  ModalHeader,
+  ModalTitle,
+  Text,
+} from '@mieweb/ui';
+import React, { createContext, useCallback, useContext, useEffect, useRef, useState } from 'react';
+
+import { notificationApi, type Notification } from '../../lib/api';
+import { useSession } from '../../lib/useSession';
+
+// ─── Context ──────────────────────────────────────────────────────────────────
+
+interface ShiftReminderCtx {
+  /** Open the modal for a specific notification (used by NotificationsPage on row click). */
+  openModal: (notif: Notification) => void;
+  /** Dismiss the modal without taking an action. */
+  closeModal: () => void;
+}
+
+const ShiftReminderContext = createContext<ShiftReminderCtx>({
+  openModal: () => {},
+  closeModal: () => {},
+});
+
+export function useShiftReminder(): ShiftReminderCtx {
+  return useContext(ShiftReminderContext);
+}
+
+// ─── Provider ─────────────────────────────────────────────────────────────────
+
+export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { user } = useSession();
+  const [pendingNotif, setPendingNotif] = useState<Notification | null>(null);
+  const [respondLoading, setRespondLoading] = useState(false);
+  const [respondError, setRespondError] = useState<string | null>(null);
+
+  // Deduplicate: track the last notification id we showed so a page reload
+  // of the same SSE event doesn't re-open an already-dismissed modal.
+  const shownIds = useRef<Set<string>>(new Set());
+
+  // Global WebSocket listener — opens on sign-in, closes on sign-out.
+  useEffect(() => {
+    if (!user) return;
+
+    const ws = notificationApi.openStream();
+    ws.onmessage = (e) => {
+      try {
+        const n = JSON.parse(e.data) as Notification;
+        if (
+          n.data?.type === 'shift-end-reminder' &&
+          !shownIds.current.has(n.id)
+        ) {
+          shownIds.current.add(n.id);
+          setPendingNotif(n);
+          setRespondError(null);
+        }
+      } catch {
+        /* ignore malformed frames */
+      }
+    };
+    return () => ws.close();
+  }, [user]);
+
+  const openModal = useCallback((notif: Notification) => {
+    shownIds.current.add(notif.id);
+    setPendingNotif(notif);
+    setRespondError(null);
+  }, []);
+
+  const closeModal = useCallback(() => {
+    setPendingNotif(null);
+    setRespondError(null);
+  }, []);
+
+  const handleAction = useCallback(
+    async (action: 'agree' | 'disagree') => {
+      if (!pendingNotif) return;
+      setRespondLoading(true);
+      try {
+        await notificationApi.respondToShiftReminder(pendingNotif.id, action);
+        closeModal();
+        // Broadcast so open inboxes can remove the notification from their list.
+        window.dispatchEvent(
+          new CustomEvent('timehuddle:shiftReminderHandled', {
+            detail: { id: pendingNotif.id },
+          }),
+        );
+      } catch (err: unknown) {
+        setRespondError(
+          err instanceof Error ? err.message : 'Failed to process response',
+        );
+      } finally {
+        setRespondLoading(false);
+      }
+    },
+    [pendingNotif, closeModal],
+  );
+
+  return (
+    <ShiftReminderContext.Provider value={{ openModal, closeModal }}>
+      {children}
+
+      <Modal
+        open={!!pendingNotif}
+        onOpenChange={(open) => !open && closeModal()}
+        size="lg"
+      >
+        <ModalHeader>
+          <ModalTitle>Shift End Reminder</ModalTitle>
+          <ModalClose />
+        </ModalHeader>
+        <ModalBody>
+          <div className="space-y-3">
+            <Text size="sm">{pendingNotif?.body}</Text>
+            <Text size="sm" variant="muted">
+              Agreeing will automatically clock you out when you reach 8 hours of work
+              time. Choosing &ldquo;Continue Working&rdquo; will send another reminder in
+              2 hours.
+            </Text>
+            {respondError && (
+              <Text size="sm" variant="destructive">
+                {respondError}
+              </Text>
+            )}
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          <Button
+            variant="outline"
+            onClick={() => handleAction('disagree')}
+            isLoading={respondLoading}
+            aria-label="Continue working — reminder in 2 hours"
+          >
+            Continue Working
+          </Button>
+          <Button
+            variant="primary"
+            onClick={() => handleAction('agree')}
+            isLoading={respondLoading}
+            aria-label="Agree to auto clock out at 8 hours"
+          >
+            Agree to Clock Out
+          </Button>
+        </ModalFooter>
+      </Modal>
+    </ShiftReminderContext.Provider>
+  );
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -888,6 +888,13 @@ export const notificationApi = {
       body: JSON.stringify({ action }),
     }),
 
+  /** Agree or disagree to the shift-end auto-clockout reminder. */
+  respondToShiftReminder: (id: string, action: 'agree' | 'disagree') =>
+    request<{ ok: boolean }>(`/v1/notifications/${encodeURIComponent(id)}/shift-respond`, {
+      method: 'POST',
+      body: JSON.stringify({ action }),
+    }),
+
   /** Send a test push notification to the requesting user's devices. */
   testPush: () => request<{ ok: boolean }>('/v1/notifications/test-push', { method: 'POST' }),
 

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -267,58 +267,58 @@ const AppLayoutContent: React.FC = () => {
         <ReportIssueModal open={reportIssueOpen} onClose={() => setReportIssueOpen(false)} />
         <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
         <ShiftReminderProvider>
-        <AppFeedbackContext.Provider
-          value={{
-            openReportIssue: () => setReportIssueOpen(true),
-            openFeedback: () => setFeedbackOpen(true),
-          }}
-        >
-          <MessagesActiveChatContext.Provider
-            value={{ setHasActiveChat: setMessagesHasActiveChat }}
+          <AppFeedbackContext.Provider
+            value={{
+              openReportIssue: () => setReportIssueOpen(true),
+              openFeedback: () => setFeedbackOpen(true),
+            }}
           >
-            <SidebarContext.Provider
-              value={{ isExpanded, isMobileOpen, toggle, openMobile, closeMobile }}
+            <MessagesActiveChatContext.Provider
+              value={{ setHasActiveChat: setMessagesHasActiveChat }}
             >
-              <div className="flex h-dvh overflow-hidden bg-neutral-50 font-sans text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-                {/* Mobile backdrop — rendered via portal to escape overflow-hidden */}
-                {isMobileOpen &&
-                  createPortal(
-                    <div
-                      className="fixed inset-0 z-45 bg-black/50 backdrop-blur-sm md:hidden"
-                      onClick={closeMobile}
-                      aria-hidden
-                    />,
-                    document.body,
-                  )}
+              <SidebarContext.Provider
+                value={{ isExpanded, isMobileOpen, toggle, openMobile, closeMobile }}
+              >
+                <div className="flex h-dvh overflow-hidden bg-neutral-50 font-sans text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+                  {/* Mobile backdrop — rendered via portal to escape overflow-hidden */}
+                  {isMobileOpen &&
+                    createPortal(
+                      <div
+                        className="fixed inset-0 z-45 bg-black/50 backdrop-blur-sm md:hidden"
+                        onClick={closeMobile}
+                        aria-hidden
+                      />,
+                      document.body,
+                    )}
 
-                <Sidebar />
+                  <Sidebar />
 
-                {/* Content column */}
-                <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                  <AppHeader title={pageTitle} />
-                  <main
-                    ref={mainRef}
-                    className={`flex-1 overflow-auto ${isMessagesPage ? `h-full ${messagesHasActiveChat ? 'pb-0' : 'app-main-scroll'}` : 'app-main-scroll'} md:pb-0`}
-                  >
-                    <PullToRefresh>
-                      {profileUserId ? (
-                        <ProfilePage userId={profileUserId} />
-                      ) : profileUsername ? (
-                        <ProfilePage username={profileUsername} />
-                      ) : ticketDetailId ? (
-                        <TicketDetailPage ticketId={ticketDetailId} />
-                      ) : (
-                        route && React.createElement(route.component)
-                      )}
-                    </PullToRefresh>
-                  </main>
+                  {/* Content column */}
+                  <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                    <AppHeader title={pageTitle} />
+                    <main
+                      ref={mainRef}
+                      className={`flex-1 overflow-auto ${isMessagesPage ? `h-full ${messagesHasActiveChat ? 'pb-0' : 'app-main-scroll'}` : 'app-main-scroll'} md:pb-0`}
+                    >
+                      <PullToRefresh>
+                        {profileUserId ? (
+                          <ProfilePage userId={profileUserId} />
+                        ) : profileUsername ? (
+                          <ProfilePage username={profileUsername} />
+                        ) : ticketDetailId ? (
+                          <TicketDetailPage ticketId={ticketDetailId} />
+                        ) : (
+                          route && React.createElement(route.component)
+                        )}
+                      </PullToRefresh>
+                    </main>
+                  </div>
+
+                  {(!isMessagesPage || !messagesHasActiveChat) && <BottomNav />}
                 </div>
-
-                {(!isMessagesPage || !messagesHasActiveChat) && <BottomNav />}
-              </div>
-            </SidebarContext.Provider>
-          </MessagesActiveChatContext.Provider>
-        </AppFeedbackContext.Provider>
+              </SidebarContext.Provider>
+            </MessagesActiveChatContext.Provider>
+          </AppFeedbackContext.Provider>
         </ShiftReminderProvider>
       </RefreshProvider>
     </RouterContext.Provider>

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -39,6 +39,7 @@ import { useSession } from '../lib/useSession';
 import { RefreshProvider } from '../lib/RefreshContext';
 import { FeedbackModal } from '../features/feedback/FeedbackModal';
 import { ReportIssueModal } from '../features/feedback/ReportIssueModal';
+import { ShiftReminderProvider } from '../features/notifications/ShiftReminderContext';
 import { AppHeader } from './AppHeader';
 import { BottomNav } from './BottomNav';
 import { CommandPalette } from './CommandPalette';
@@ -265,6 +266,7 @@ const AppLayoutContent: React.FC = () => {
         <CommandPalette />
         <ReportIssueModal open={reportIssueOpen} onClose={() => setReportIssueOpen(false)} />
         <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
+        <ShiftReminderProvider>
         <AppFeedbackContext.Provider
           value={{
             openReportIssue: () => setReportIssueOpen(true),
@@ -317,6 +319,7 @@ const AppLayoutContent: React.FC = () => {
             </SidebarContext.Provider>
           </MessagesActiveChatContext.Provider>
         </AppFeedbackContext.Provider>
+        </ShiftReminderProvider>
       </RefreshProvider>
     </RouterContext.Provider>
   );


### PR DESCRIPTION
This pull request implements a comprehensive shift-end reminder and auto-clockout system for long-running clock events. It introduces new fields to the backend, a periodic monitor that sends reminders and auto-clocks out users after 8 hours, user response handling for reminders, and updates to the notification system and UI to support this workflow.

**Backend: Shift-End Reminder and Auto-Clockout Logic**

* Database migration adds four new fields to `clockevents` for tracking shift-end reminders, auto-clockout thresholds, repeat reminders, and user responses.
* The `ClockMonitorService` now:
  * Sends a shift-end reminder at 7h45m, and schedules auto-clockout at 8h.
  * Auto-clocks out users at the 8h threshold, notifies both users and admins, and supports a 2h repeat reminder cycle if the user disagrees.
  * Notifies admins with different messages depending on user response.
* The `ClockEvent` model and API now include the new shift reminder fields. 

**Backend: User Response Handling**

* Adds a new POST endpoint `/v1/notifications/:id/shift-respond` for users to agree or disagree with shift-end reminders.
* Implements `respondToShiftReminder` to update clock event state and schedule/cancel auto-clockout or repeat reminders based on user action.

**Frontend: Notification and Modal Integration**

* Integrates shift-end reminders into the notifications UI: opening a modal for user response and updating the notification list accordingly. 
* Ensures notifications are removed from the list when handled via the shift reminder modal.

These changes together provide a robust, auditable workflow for shift-end management and automatic clockout, improving compliance and user/admin awareness.

---

**Most important changes:**

**Backend: Shift-End Reminder & Auto-Clockout**
- Added migration and model fields for shift-end reminder tracking in `clockevents`. 
- Implemented periodic shift monitoring: sends 7h45m reminders, auto-clocks out at 8h, and handles 2h repeat reminders. Notifies both users and admins with context-aware messages.

**Backend: User Response Handling**
- Added `/v1/notifications/:id/shift-respond` endpoint and `respondToShiftReminder` logic to process user agree/disagree actions, updating event state and scheduling next steps. 

**Frontend: Notification Integration**
- Updated notifications UI to handle shift-end reminders: opens modal for response, marks notification as read, and removes it after handling. 
**API & Serialization**
- Updated API and serialization to include new shift reminder fields in clock event objects. 