### PR TITLE
When clicked on to specific notification should naviagte to members profile page work on members profile page first

### DIFF
--- a/backend/package.json
+++ b/backend/package.json
@@ -21,6 +21,7 @@
     "format:fix": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\" \"scripts/**/*.ts\""
   },
   "dependencies": {
+    "@agendajs/mongo-backend": "^4.0.2",
     "@better-auth/core": "^1.6.9",
     "@casl/ability": "^6.8.1",
     "@casl/mongoose": "^8.0.5",
@@ -33,7 +34,6 @@
     "@mieweb/pulsevault": "^0.0.2",
     "@noble/ciphers": "^2.2.0",
     "@parse/node-apn": "^7.1.0",
-    "@agendajs/mongo-backend": "^4.0.2",
     "@timehuddle/youtube": "*",
     "agenda": "^6.2.5",
     "bcrypt": "^6.0.0",

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -343,7 +343,7 @@ export class ClockService {
               userName,
               teamName: team.name,
               teamId,
-              url: `/app/clock`,
+              url: `/app/profile/${userId}?tab=work`,
             },
           })
           .catch(() => {})
@@ -429,7 +429,7 @@ export class ClockService {
                 teamName: team.name,
                 teamId,
                 duration: durationText,
-                url: `/app/clock`,
+                url: `/app/profile/${userId}?tab=work`,
               },
             })
             .catch(() => {})
@@ -447,7 +447,7 @@ export class ClockService {
             teamName: team.name,
             teamId,
             duration: durationText,
-            url: `/app/clock`,
+            url: `/app/profile/${userId}?tab=work`,
           },
         })
         .catch(() => {});

--- a/e2e/notification-deeplink.spec.ts
+++ b/e2e/notification-deeplink.spec.ts
@@ -122,7 +122,7 @@ async function clockOut(page: Page, teamId: string): Promise<void> {
   if (!res.ok()) throw new Error(`Clock out failed: ${res.status()} ${await res.text()}`);
 }
 
-async function ensureClockedOut(page: Page, teamId: string): Promise<void> {
+async function ensureClockedOut(page: Page, _teamId: string): Promise<void> {
   const res = await page.request.get(`${API_BASE}/clock/active`);
   const { event } = (await res.json()) as { event: { teamId: string } | null };
   if (!event) return;

--- a/e2e/notification-deeplink.spec.ts
+++ b/e2e/notification-deeplink.spec.ts
@@ -1,0 +1,253 @@
+/**
+ * Notification Deep-Link E2E
+ *
+ * Verifies that push notification payloads contain the correct deep-link URLs
+ * and that navigating to those URLs lands on the expected page/tab:
+ *
+ *  1. clock-in admin notification  → url is /app/profile/:memberId?tab=work
+ *  2. clock-out admin notification → url is /app/profile/:memberId?tab=work
+ *  3. clock-out-self notification  → url is /app/profile/:userId?tab=work
+ *  4. Navigating to /app/profile/:userId?tab=work opens the Work tab, not Feed
+ *  5. Navigating to /app/profile/:userId (no tab param) opens the Feed tab (default)
+ *
+ * Setup: Alice (admin) + Bob (member) in a shared team.
+ * Bob performs clock actions; Alice's notifications are asserted after each.
+ */
+
+import { expect, test, type Page } from '@playwright/test';
+
+const BOB_EMAIL = 'bob@example.com';
+const BOB_PASSWORD = 'Password1!';
+const ALICE_EMAIL = 'alice@example.com';
+const ALICE_PASSWORD = 'Password1!';
+// Bob's userId is stable — seeded once and never changes (matches shift-reminder.spec.ts)
+const BOB_USER_ID = '69f4f84156731a5f77a8a8a4';
+const API_BASE = 'http://localhost:4000/v1';
+
+type Notification = {
+  id: string;
+  title: string;
+  body: string;
+  read: boolean;
+  data?: Record<string, unknown>;
+};
+
+// ─── Auth helpers ──────────────────────────────────────────────────────────────
+
+async function loginAs(page: Page, email: string, password: string) {
+  const res = await page.request.post(`http://localhost:4000/api/auth/sign-in/email`, {
+    data: { email, password },
+  });
+  if (!res.ok()) {
+    throw new Error(`Login failed for ${email}: ${res.status()} ${await res.text()}`);
+  }
+}
+
+// ─── Notification helpers ──────────────────────────────────────────────────────
+
+async function getNotifications(page: Page): Promise<Notification[]> {
+  const res = await page.request.get(`${API_BASE}/notifications`);
+  if (!res.ok()) throw new Error(`getNotifications failed: ${res.status()}`);
+  const body = (await res.json()) as { notifications: Notification[] };
+  return body.notifications ?? [];
+}
+
+async function clearNotifications(page: Page): Promise<void> {
+  const notifications = await getNotifications(page);
+  if (!notifications.length) return;
+  await page.request.delete(`${API_BASE}/notifications`, {
+    data: { ids: notifications.map((n) => n.id) },
+  });
+}
+
+/** Wait up to 10 s for a notification matching the predicate to appear. */
+async function waitForNotification(
+  page: Page,
+  predicate: (n: Notification) => boolean,
+  timeoutMs = 10000,
+): Promise<Notification> {
+  const deadline = Date.now() + timeoutMs;
+  while (Date.now() < deadline) {
+    const notifications = await getNotifications(page);
+    const match = notifications.find(predicate);
+    if (match) return match;
+    await page.waitForTimeout(500);
+  }
+  throw new Error('waitForNotification: timed out');
+}
+
+// ─── Team helpers ──────────────────────────────────────────────────────────────
+
+async function setupTestTeam(
+  alicePage: Page,
+  bobPage: Page,
+): Promise<{ teamId: string; teamName: string }> {
+  const teamName = `E2E DeepLink ${Date.now()}`;
+  const createRes = await alicePage.request.post(`${API_BASE}/teams`, {
+    data: { name: teamName },
+  });
+  if (!createRes.ok()) throw new Error(`Team creation failed: ${createRes.status()}`);
+  const { team } = (await createRes.json()) as { team: { id: string; code: string } };
+
+  const joinRes = await bobPage.request.post(`${API_BASE}/teams/join`, {
+    data: { teamCode: team.code },
+  });
+  if (!joinRes.ok()) throw new Error(`Bob join failed: ${joinRes.status()}`);
+
+  return { teamId: team.id, teamName };
+}
+
+async function teardownTestTeam(alicePage: Page, teamId: string): Promise<void> {
+  await alicePage.request.delete(`${API_BASE}/teams/${teamId}`).catch(() => {});
+}
+
+// ─── Clock helpers ─────────────────────────────────────────────────────────────
+
+async function clockIn(
+  page: Page,
+  teamId: string,
+): Promise<{ eventId: string }> {
+  const res = await page.request.post(`${API_BASE}/clock/start`, {
+    data: { teamId },
+  });
+  if (!res.ok()) throw new Error(`Clock in failed: ${res.status()} ${await res.text()}`);
+  const body = (await res.json()) as { event: { id: string } };
+  return { eventId: body.event.id };
+}
+
+async function clockOut(page: Page, teamId: string): Promise<void> {
+  const res = await page.request.post(`${API_BASE}/clock/stop`, {
+    data: { teamId },
+  });
+  if (!res.ok()) throw new Error(`Clock out failed: ${res.status()} ${await res.text()}`);
+}
+
+async function ensureClockedOut(page: Page, teamId: string): Promise<void> {
+  const res = await page.request.get(`${API_BASE}/clock/active`);
+  const { event } = (await res.json()) as { event: { teamId: string } | null };
+  if (!event) return;
+  await page.request.post(`${API_BASE}/clock/stop`, { data: { teamId: event.teamId } });
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+test.describe('Notification deep-links', () => {
+  test.setTimeout(60000);
+
+  let alicePage: Page;
+  let bobPage: Page;
+  let teamId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    // Two independent browser contexts — one per user
+    alicePage = await (await browser.newContext()).newPage();
+    bobPage = await (await browser.newContext()).newPage();
+
+    // Log both users in via the API (sets session cookie on request context)
+    await Promise.all([
+      loginAs(alicePage, ALICE_EMAIL, ALICE_PASSWORD),
+      loginAs(bobPage, BOB_EMAIL, BOB_PASSWORD),
+    ]);
+
+    // Create shared team
+    ({ teamId } = await setupTestTeam(alicePage, bobPage));
+  });
+
+  test.afterAll(async () => {
+    await teardownTestTeam(alicePage, teamId);
+    await alicePage.context().close();
+    await bobPage.context().close();
+  });
+
+  test.beforeEach(async () => {
+    await clearNotifications(alicePage);
+    await clearNotifications(bobPage);
+    await ensureClockedOut(bobPage, teamId);
+  });
+
+  // ── 1. clock-in notification URL ─────────────────────────────────────────────
+
+  test('clock-in notification has url /app/profile/:memberId?tab=work', async () => {
+    await clockIn(bobPage, teamId);
+
+    const notif = await waitForNotification(
+      alicePage,
+      (n) => n.data?.type === 'clock-in' && (n.data?.userId as string) === BOB_USER_ID,
+    );
+
+    expect(notif.data?.url).toBe(`/app/profile/${BOB_USER_ID}?tab=work`);
+  });
+
+  // ── 2. clock-out notification URL ────────────────────────────────────────────
+
+  test('clock-out admin notification has url /app/profile/:memberId?tab=work', async () => {
+    await clockIn(bobPage, teamId);
+    await clockOut(bobPage, teamId);
+
+    const notif = await waitForNotification(
+      alicePage,
+      (n) => n.data?.type === 'clock-out' && (n.data?.userId as string) === BOB_USER_ID,
+    );
+
+    expect(notif.data?.url).toBe(`/app/profile/${BOB_USER_ID}?tab=work`);
+  });
+
+  // ── 3. clock-out-self notification URL ───────────────────────────────────────
+
+  test('clock-out-self notification has url /app/profile/:userId?tab=work', async () => {
+    await clockIn(bobPage, teamId);
+    await clockOut(bobPage, teamId);
+
+    const notif = await waitForNotification(
+      bobPage,
+      (n) => n.data?.type === 'clock-out-self',
+    );
+
+    expect(notif.data?.url).toBe(`/app/profile/${BOB_USER_ID}?tab=work`);
+  });
+
+  // ── 4. Navigating to ?tab=work opens Work tab ────────────────────────────────
+
+  test('navigating to /app/profile/:userId?tab=work opens Work tab', async ({ page }) => {
+    // Full UI login so the app's localStorage Bearer token is set
+    await page.goto('/app');
+    await page.waitForSelector('input[type="email"]', { timeout: 10000 });
+    await page.fill('input[type="email"]', ALICE_EMAIL);
+    await page.fill('input[type="password"]', ALICE_PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15000 });
+
+    await page.goto(`/app/profile/${BOB_USER_ID}?tab=work`);
+
+    // Work tab should be the active (selected) tab
+    const workTab = page.getByRole('tab', { name: 'Work' });
+    await expect(workTab).toBeVisible({ timeout: 15000 });
+    await expect(workTab).toHaveAttribute('data-state', 'active');
+
+    // Feed tab should not be active
+    const feedTab = page.getByRole('tab', { name: 'Feed' });
+    await expect(feedTab).toHaveAttribute('data-state', 'inactive');
+  });
+
+  // ── 5. Default (no tab param) opens Feed tab ─────────────────────────────────
+
+  test('navigating to /app/profile/:userId without ?tab opens Feed tab by default', async ({
+    page,
+  }) => {
+    await page.goto('/app');
+    await page.waitForSelector('input[type="email"]', { timeout: 10000 });
+    await page.fill('input[type="email"]', ALICE_EMAIL);
+    await page.fill('input[type="password"]', ALICE_PASSWORD);
+    await page.getByRole('button', { name: 'Sign in' }).click();
+    await page.waitForURL('**/dashboard', { timeout: 15000 });
+
+    await page.goto(`/app/profile/${BOB_USER_ID}`);
+
+    const feedTab = page.getByRole('tab', { name: 'Feed' });
+    await expect(feedTab).toBeVisible({ timeout: 15000 });
+    await expect(feedTab).toHaveAttribute('data-state', 'active');
+
+    const workTab = page.getByRole('tab', { name: 'Work' });
+    await expect(workTab).toHaveAttribute('data-state', 'inactive');
+  });
+});

--- a/e2e/notification-deeplink.spec.ts
+++ b/e2e/notification-deeplink.spec.ts
@@ -103,10 +103,7 @@ async function teardownTestTeam(alicePage: Page, teamId: string): Promise<void> 
 
 // ─── Clock helpers ─────────────────────────────────────────────────────────────
 
-async function clockIn(
-  page: Page,
-  teamId: string,
-): Promise<{ eventId: string }> {
+async function clockIn(page: Page, teamId: string): Promise<{ eventId: string }> {
   const res = await page.request.post(`${API_BASE}/clock/start`, {
     data: { teamId },
   });
@@ -198,10 +195,7 @@ test.describe('Notification deep-links', () => {
     await clockIn(bobPage, teamId);
     await clockOut(bobPage, teamId);
 
-    const notif = await waitForNotification(
-      bobPage,
-      (n) => n.data?.type === 'clock-out-self',
-    );
+    const notif = await waitForNotification(bobPage, (n) => n.data?.type === 'clock-out-self');
 
     expect(notif.data?.url).toBe(`/app/profile/${BOB_USER_ID}?tab=work`);
   });

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "backend"
       ],
       "dependencies": {
-        "@agendajs/mongo-backend": "^4.0.2",
         "@babel/runtime": "^7.28.4",
         "@capacitor/app": "^8.1.0",
         "@capacitor/browser": "^8.0.3",
@@ -88,6 +87,7 @@
       "name": "timeharbor-timehuddle-backend",
       "version": "1.0.0",
       "dependencies": {
+        "@agendajs/mongo-backend": "^4.0.2",
         "@better-auth/core": "^1.6.9",
         "@casl/ability": "^6.8.1",
         "@casl/mongoose": "^8.0.5",

--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -13,5 +13,6 @@ export default defineConfig({
     launchOptions: {
       slowMo: process.env.PWSLOWMO ? parseInt(process.env.PWSLOWMO, 10) : 0,
     },
+    video: process.env.PWVIDEO ? 'on' : 'off',
   },
 });

--- a/public/sw.js
+++ b/public/sw.js
@@ -63,9 +63,36 @@ self.addEventListener('notificationclick', function (event) {
   event.notification.close();
 
   const notificationData = event.notification.data || {};
+
+  // shift-end-reminder: post a message to the open window so the app can open
+  // the shift-end modal in-place, without navigating away from the current page.
+  if (notificationData.type === 'shift-end-reminder') {
+    event.waitUntil(
+      clients
+        .matchAll({ type: 'window', includeUncontrolled: true })
+        .then(function (windowClients) {
+          const msg = {
+            type: 'timehuddle:openShiftReminder',
+            clockEventId: notificationData.clockEventId,
+            teamId: notificationData.teamId,
+          };
+          if (windowClients.length > 0) {
+            windowClients[0].postMessage(msg);
+            return windowClients[0].focus();
+          }
+          // No open window — open the app; ShiftReminderContext will hydrate from inbox on load
+          if (clients.openWindow) {
+            return clients.openWindow('/app/dashboard');
+          }
+        })
+        .catch((err) => console.error('[Service Worker] Error handling notification click:', err)),
+    );
+    return;
+  }
+
   let urlToOpen = notificationData.url || event.notification.data?.url || '/app/dashboard';
 
-  // Normalise legacy paths
+  // Normalise legacy paths (preserve query string)
   if (typeof urlToOpen === 'string' && urlToOpen.startsWith('/') && !urlToOpen.startsWith('/app')) {
     if (urlToOpen === '/' || urlToOpen === '') urlToOpen = '/app/dashboard';
     else if (urlToOpen.startsWith('/member/')) urlToOpen = '/app/clock';

--- a/src/features/notifications/ShiftReminderContext.tsx
+++ b/src/features/notifications/ShiftReminderContext.tsx
@@ -137,6 +137,31 @@ export const ShiftReminderProvider: React.FC<{ children: React.ReactNode }> = ({
     setRespondError(null);
   }, []);
 
+  // Push notification tap (web SW postMessage or native Capacitor) dispatches
+  // 'timehuddle:openShiftReminder' — find the matching inbox notification and open the modal.
+  useEffect(() => {
+    if (!user) return;
+    const handler = (e: Event) => {
+      const { clockEventId } = (e as CustomEvent<{ clockEventId?: string; teamId?: string }>)
+        .detail;
+      notificationApi
+        .getInbox()
+        .then((notifications: Notification[]) => {
+          const match = notifications.find(
+            (n) => n.data?.type === 'shift-end-reminder' && n.data?.clockEventId === clockEventId,
+          );
+          if (!match) return;
+          const dedupeKey = clockEventId ?? match.id;
+          // Allow re-opening via tap even if already deduped in this session
+          shownIds.current.delete(dedupeKey);
+          openModal(match);
+        })
+        .catch(() => {});
+    };
+    window.addEventListener('timehuddle:openShiftReminder', handler);
+    return () => window.removeEventListener('timehuddle:openShiftReminder', handler);
+  }, [user, openModal]);
+
   const closeModal = useCallback(() => {
     setPendingNotif(null);
     setRespondError(null);

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -367,7 +367,10 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId, username }) =>
 
       {/* Tab rail — Feed | Work | Activity */}
       {profile && (
-        <Tabs defaultValue="feed" className="w-full">
+        <Tabs
+          defaultValue={new URLSearchParams(window.location.search).get('tab') ?? 'feed'}
+          className="w-full"
+        >
           <TabsList className="mb-4 w-full">
             <TabsTrigger value="feed" className="flex-1">
               Feed

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -40,6 +40,7 @@ import { ProfileActivityFeed } from './ProfileActivityFeed';
 import { ProfileFeed } from './ProfileFeed';
 import { ProfileWorkSnapshot } from './ProfileWorkSnapshot';
 import { WorkSummaryTags } from './WorkSummaryTags';
+import { TodayStatusCard } from '../timers/TodayStatusCard';
 
 type ProfilePageProps = { userId: string; username?: never } | { username: string; userId?: never };
 
@@ -390,6 +391,9 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId, username }) =>
 
           {/* Work tab */}
           <TabsContent value="work" className="flex flex-col gap-4">
+            {/* Today's clock status — own profile only */}
+            {isOwn && <TodayStatusCard />}
+
             {/* 48 h work summary */}
             <WorkSummaryTags userId={profile.id} />
 

--- a/src/features/timers/TodayStatusCard.tsx
+++ b/src/features/timers/TodayStatusCard.tsx
@@ -1,0 +1,130 @@
+/**
+ * TodayStatusCard — shows the user's current clock-in status and active ticket.
+ * Only rendered when the user is clocked in.
+ */
+import { faClock, faPlay } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Badge, Card, CardContent, Text } from '@mieweb/ui';
+import { useCallback, useEffect, useState } from 'react';
+
+import { timerApi, ticketApi, type DayEntry, type Ticket } from '../../lib/api';
+import { useTeam } from '../../lib/TeamContext';
+import { formatDuration, formatTime, formatTimer, getActiveClockSeconds } from '../../lib/timeUtils';
+import { useRouter } from '../../ui/router';
+
+export function TodayStatusCard() {
+  const { activeClockEvent, currentTime } = useTeam();
+  const { navigate } = useRouter();
+  const [todayEntries, setTodayEntries] = useState<DayEntry[]>([]);
+  const [runningTicket, setRunningTicket] = useState<Ticket | null>(null);
+
+  const fetchToday = useCallback(() => {
+    timerApi.getToday().then(setTodayEntries).catch(() => {});
+  }, []);
+
+  // Fetch on mount and whenever clock-in state changes
+  useEffect(() => {
+    if (!activeClockEvent) return;
+    fetchToday();
+  }, [activeClockEvent, fetchToday]);
+
+  // Re-fetch when timer mutations occur (WorkPage broadcasts this event)
+  useEffect(() => {
+    window.addEventListener('work:refetch', fetchToday);
+    return () => window.removeEventListener('work:refetch', fetchToday);
+  }, [fetchToday]);
+
+  // Fetch full ticket when the running entry changes (needed for github field)
+  useEffect(() => {
+    const runningEntry = todayEntries.find((de) => de.sessions.some((s) => s.endTime === null));
+    if (!runningEntry) {
+      setRunningTicket(null);
+      return;
+    }
+    ticketApi.getTicket(runningEntry.entry.ticketId).then(setRunningTicket).catch(() => setRunningTicket(null));
+  }, [todayEntries]);
+
+  // Not clocked in — hide card entirely
+  if (!activeClockEvent) return null;
+
+  // Find the entry with a running session (endTime === null)
+  const runningEntry = todayEntries.find((de) =>
+    de.sessions.some((s) => s.endTime === null),
+  );
+  const runningSession = runningEntry?.sessions.find((s) => s.endTime === null) ?? null;
+
+  const clockedInSeconds = getActiveClockSeconds(activeClockEvent, currentTime);
+  const activeTicketSeconds = runningSession
+    ? Math.max(0, Math.floor((currentTime - runningSession.startTime) / 1000))
+    : 0;
+
+  const ticketTitle = runningEntry?.entry.displayTitle ?? runningEntry?.entry.ticketId ?? null;
+  const clockInTime = formatTime(new Date(activeClockEvent.startTime));
+  const ticketStartTime = runningSession ? formatTime(new Date(runningSession.startTime)) : null;
+
+  // Determine click behaviour: GitHub URL → external, otherwise in-app ticket detail
+  const handleTicketClick = () => {
+    if (!runningEntry) return;
+    if (runningTicket?.github) {
+      window.open(runningTicket.github, '_blank', 'noopener,noreferrer');
+    } else {
+      navigate(`/app/tickets/${runningEntry.entry.ticketId}`);
+    }
+  };
+
+  return (
+    <Card padding="sm" aria-label="Today's status">
+      <CardContent>
+        <div className="flex flex-col gap-3">
+          {/* Clock-in status */}
+          <div className="flex items-center gap-2 min-w-0">
+            <FontAwesomeIcon icon={faClock} className="text-success shrink-0" />
+            <Text size="sm" className="min-w-0">
+              <span className="font-medium">Clocked in</span>
+              <span className="text-muted-foreground"> since {clockInTime}</span>
+            </Text>
+            <Badge variant="success" size="sm" className="shrink-0 font-mono ml-auto">
+              {formatTimer(clockedInSeconds)}
+            </Badge>
+          </div>
+
+          {/* Divider */}
+          <div className="h-px bg-border" aria-hidden="true" />
+
+          {/* Active ticket */}
+          <div className="flex items-center gap-2 min-w-0">
+            <FontAwesomeIcon
+              icon={faPlay}
+              className={runningEntry ? 'text-primary shrink-0' : 'text-muted-foreground shrink-0'}
+            />
+            {runningEntry && ticketTitle ? (
+              <>
+                <Text size="sm" className="min-w-0 truncate flex-1">
+                  <span className="text-muted-foreground">Working on: </span>
+                  <button
+                    type="button"
+                    onClick={handleTicketClick}
+                    className="font-medium hover:underline focus:outline-none focus-visible:underline"
+                    aria-label={`Open ticket: ${ticketTitle}`}
+                  >
+                    {ticketTitle}
+                  </button>
+                  {ticketStartTime && (
+                    <span className="text-muted-foreground"> · since {ticketStartTime}</span>
+                  )}
+                </Text>
+                <Badge variant="secondary" size="sm" className="shrink-0 font-mono">
+                  {formatDuration(activeTicketSeconds)}
+                </Badge>
+              </>
+            ) : (
+              <Text size="sm" className="text-muted-foreground">
+                No active ticket
+              </Text>
+            )}
+          </div>
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/features/timers/TodayStatusCard.tsx
+++ b/src/features/timers/TodayStatusCard.tsx
@@ -9,7 +9,12 @@ import { useCallback, useEffect, useState } from 'react';
 
 import { timerApi, ticketApi, type DayEntry, type Ticket } from '../../lib/api';
 import { useTeam } from '../../lib/TeamContext';
-import { formatDuration, formatTime, formatTimer, getActiveClockSeconds } from '../../lib/timeUtils';
+import {
+  formatDuration,
+  formatTime,
+  formatTimer,
+  getActiveClockSeconds,
+} from '../../lib/timeUtils';
 import { useRouter } from '../../ui/router';
 
 export function TodayStatusCard() {
@@ -19,7 +24,10 @@ export function TodayStatusCard() {
   const [runningTicket, setRunningTicket] = useState<Ticket | null>(null);
 
   const fetchToday = useCallback(() => {
-    timerApi.getToday().then(setTodayEntries).catch(() => {});
+    timerApi
+      .getToday()
+      .then(setTodayEntries)
+      .catch(() => {});
   }, []);
 
   // Fetch on mount and whenever clock-in state changes
@@ -41,16 +49,17 @@ export function TodayStatusCard() {
       setRunningTicket(null);
       return;
     }
-    ticketApi.getTicket(runningEntry.entry.ticketId).then(setRunningTicket).catch(() => setRunningTicket(null));
+    ticketApi
+      .getTicket(runningEntry.entry.ticketId)
+      .then(setRunningTicket)
+      .catch(() => setRunningTicket(null));
   }, [todayEntries]);
 
   // Not clocked in — hide card entirely
   if (!activeClockEvent) return null;
 
   // Find the entry with a running session (endTime === null)
-  const runningEntry = todayEntries.find((de) =>
-    de.sessions.some((s) => s.endTime === null),
-  );
+  const runningEntry = todayEntries.find((de) => de.sessions.some((s) => s.endTime === null));
   const runningSession = runningEntry?.sessions.find((s) => s.endTime === null) ?? null;
 
   const clockedInSeconds = getActiveClockSeconds(activeClockEvent, currentTime);

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -55,6 +55,7 @@ import { useRefresh } from '../../lib/RefreshContext';
 import { formatDuration } from '../../lib/timeUtils';
 import { useClockToggle } from '../../lib/useClockToggle';
 import { AppPage } from '../../ui/AppPage';
+import { TodayStatusCard } from './TodayStatusCard';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -592,6 +593,9 @@ export const WorkPage: React.FC = () => {
           </Button>
         </div>
       </div>
+
+      {/* ── Today Status Card ── */}
+      <TodayStatusCard />
 
       {/* ── Week Strip + Add Button ── */}
       <div className="flex flex-col gap-2 sm:gap-0">

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1047,9 +1047,9 @@ export const timerApi = {
   /** Get all entries + sessions for today in local time. */
   getToday: () => {
     const tz = clientTz();
-    return request<{ entries: DayEntry[] }>(
-      `/v1/timers/today?tz=${encodeURIComponent(tz)}`,
-    ).then((r) => r.entries);
+    return request<{ entries: DayEntry[] }>(`/v1/timers/today?tz=${encodeURIComponent(tz)}`).then(
+      (r) => r.entries,
+    );
   },
 
   /** Get all entries + sessions for a local day (YYYY-MM-DD). */

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1044,6 +1044,14 @@ export const timerApi = {
   /** Get the currently running timer for the authenticated user, or null. */
   getRunning: () => request<{ session: Timer | null }>('/v1/timers/running').then((r) => r.session),
 
+  /** Get all entries + sessions for today in local time. */
+  getToday: () => {
+    const tz = clientTz();
+    return request<{ entries: DayEntry[] }>(
+      `/v1/timers/today?tz=${encodeURIComponent(tz)}`,
+    ).then((r) => r.entries);
+  },
+
   /** Get all entries + sessions for a local day (YYYY-MM-DD). */
   getDay: (date: string) => {
     const tz = clientTz();

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -146,7 +146,7 @@ const AppLayoutContent: React.FC = () => {
 
   const navigate = useCallback((path: string) => {
     window.history.pushState(null, '', path);
-    setPathname(path);
+    setPathname(path.split('?')[0]);
   }, []);
 
   // Keep in sync with browser back/forward
@@ -183,10 +183,16 @@ const AppLayoutContent: React.FC = () => {
           }),
         );
         navigate('/app/messages');
+      } else if (data.type === 'shift-end-reminder') {
+        window.dispatchEvent(
+          new CustomEvent('timehuddle:openShiftReminder', {
+            detail: { clockEventId: data.clockEventId, teamId: data.teamId },
+          }),
+        );
       } else if (data.url) {
         const safePath = data.url.split('?')[0];
         if (safePath.startsWith('/app/')) {
-          navigate(safePath);
+          navigate(data.url); // preserve query string (e.g. ?tab=work)
         }
       }
     })
@@ -200,6 +206,21 @@ const AppLayoutContent: React.FC = () => {
       handle?.remove();
     };
   }, [navigate]);
+
+  // Web push: service worker posts a message to open the shift-end-reminder modal
+  // without navigating away from the current page.
+  useEffect(() => {
+    if (!('serviceWorker' in navigator)) return;
+    const handler = (event: MessageEvent) => {
+      if (event.data?.type === 'timehuddle:openShiftReminder') {
+        window.dispatchEvent(
+          new CustomEvent('timehuddle:openShiftReminder', { detail: event.data }),
+        );
+      }
+    };
+    navigator.serviceWorker.addEventListener('message', handler);
+    return () => navigator.serviceWorker.removeEventListener('message', handler);
+  }, []);
 
   // Parameterized profile route — /app/profile/:userId
   const profileUserId = pathname.startsWith('/app/profile/')


### PR DESCRIPTION
This pull request introduces several improvements to notification deep-linking, user experience, and test coverage related to clock-in/clock-out notifications and the profile Work tab. The main changes include updating notification URLs for clock events, ensuring the correct tab is opened via deep-link, adding a new `TodayStatusCard` component to display current clock-in status, and enhancing both service worker and frontend handling for shift reminders. Additionally, comprehensive E2E tests were added to verify these behaviors.

**Notification Deep-Linking and Profile Tab Improvements:**

* Clock-in, clock-out, and clock-out-self notifications now include a deep-link URL to `/app/profile/:userId?tab=work` instead of the generic `/app/clock`, ensuring admins and users are directed to the correct Work tab on the profile page. (`backend/src/services/clock.service.ts`) 
* The `ProfilePage` component now reads the `tab` query parameter from the URL to set the default active tab, so deep-links like `?tab=work` open the Work tab directly. (`src/features/profile/ProfilePage.tsx`)

**User Interface Enhancements:**

* Introduced a new `TodayStatusCard` component that displays the user's current clock-in status and active ticket, shown on both the Work tab of the profile and the Work page itself. (`src/features/timers/TodayStatusCard.tsx`, `src/features/profile/ProfilePage.tsx`, `src/features/timers/WorkPage.tsx`) 

**Service Worker and Notification Handling:**

* The service worker (`public/sw.js`) now handles `shift-end-reminder` notifications by posting a message to open the shift reminder modal in-place, without navigating away from the current page. (`public/sw.js`)
* The `ShiftReminderContext` listens for these messages and opens the relevant modal, improving the user experience on notification tap. (`src/features/notifications/ShiftReminderContext.tsx`)

**Testing and Configuration:**

* Added a comprehensive Playwright E2E test suite to verify notification payloads, deep-link URLs, and tab selection behavior. (`e2e/notification-deeplink.spec.ts`)
* Playwright config now supports video recording based on the `PWVIDEO` environment variable. (`playwright.config.ts`)

**Dependency Cleanup:**

* Removed a duplicate dependency for `@agendajs/mongo-backend` from `backend/package.json`. (`backend/package.json`) 