### PR TITLE
Dashboard should have all the teams related info

### DIFF
--- a/backend/src/routes/clock.ts
+++ b/backend/src/routes/clock.ts
@@ -9,11 +9,7 @@ import {
   computeWorkSeconds,
 } from "../services/clock.service.js";
 import { findBreaksForEvents } from "../models/clock.model.js";
-import {
-  teamsCollection,
-  usersCollection,
-  profilesCollection,
-} from "../models/index.js";
+import { teamsCollection, usersCollection, profilesCollection } from "../models/index.js";
 import { clockController } from "../controllers/clock.controller.js";
 
 // ─── Public shape schema ──────────────────────────────────────────────────────
@@ -377,7 +373,11 @@ export async function clockRoutes(app: FastifyInstance) {
       const [users, profiles] = await Promise.all([
         usersCollection()
           .find({ _id: { $in: validIds.map((id) => new ObjectId(id)) } })
-          .project<{ _id: ObjectId; name: string; image: string | null }>({ _id: 1, name: 1, image: 1 })
+          .project<{ _id: ObjectId; name: string; image: string | null }>({
+            _id: 1,
+            name: 1,
+            image: 1,
+          })
           .toArray(),
         profilesCollection()
           .find({ userId: { $in: allMemberIds }, app: "timeharbor" })

--- a/backend/src/routes/clock.ts
+++ b/backend/src/routes/clock.ts
@@ -2,9 +2,18 @@ import { FastifyInstance } from "fastify";
 import { ObjectId } from "mongodb";
 import { auth } from "../lib/auth.js";
 import { requireAuth } from "../middleware/require-auth.js";
-import { clockService, toPublicClockEvent, subscribe } from "../services/clock.service.js";
+import {
+  clockService,
+  toPublicClockEvent,
+  subscribe,
+  computeWorkSeconds,
+} from "../services/clock.service.js";
 import { findBreaksForEvents } from "../models/clock.model.js";
-import { teamsCollection } from "../models/index.js";
+import {
+  teamsCollection,
+  usersCollection,
+  profilesCollection,
+} from "../models/index.js";
 import { clockController } from "../controllers/clock.controller.js";
 
 // ─── Public shape schema ──────────────────────────────────────────────────────
@@ -249,6 +258,150 @@ export async function clockRoutes(app: FastifyInstance) {
       },
     },
     clockController.getActive
+  );
+
+  // GET /v1/clock/team-status?teamId=xxx — active clock events for all team members + today's hours
+  app.get(
+    "/clock/team-status",
+    {
+      onRequest: [requireAuth],
+      schema: {
+        tags: ["Clock"],
+        summary: "Get active clock events and today's hours for all team members",
+        querystring: {
+          type: "object",
+          required: ["teamId"],
+          properties: { teamId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              members: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    userId: { type: "string" },
+                    name: { type: "string" },
+                    image: { type: "string", nullable: true },
+                    isClockedIn: { type: "boolean" },
+                    isOnBreak: { type: "boolean" },
+                    activeClockStart: { type: "number", nullable: true },
+                    todaySeconds: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+          403: { type: "object", properties: { error: { type: "string" } } },
+          404: { type: "object", properties: { error: { type: "string" } } },
+        },
+      },
+    },
+    async (req, reply) => {
+      const { id: requestingUserId } = (req as any).user;
+      const { teamId } = req.query as { teamId: string };
+
+      if (!/^[0-9a-f]{24}$/i.test(teamId)) {
+        return reply.code(404).send({ error: "Team not found" });
+      }
+
+      const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
+      if (!team) return reply.code(404).send({ error: "Team not found" });
+
+      const allMemberIds = Array.from(new Set([...team.members, ...team.admins]));
+      if (!allMemberIds.includes(requestingUserId)) {
+        return reply.code(403).send({ error: "Forbidden" });
+      }
+
+      // Get today's start (UTC midnight)
+      const todayStart = new Date();
+      todayStart.setUTCHours(0, 0, 0, 0);
+      const todayStartMs = todayStart.getTime();
+      const now = Date.now();
+
+      // Get active and today's clock events for all members
+      const { clockEventsCollection } = await import("../models/index.js");
+      const clockEvents = await clockEventsCollection()
+        .find({
+          userId: { $in: allMemberIds },
+          teamId,
+          startTime: { $gte: todayStartMs },
+        })
+        .toArray();
+
+      // Load all breaks for today's events in a single query
+      const eventIds = clockEvents.map((e) => e._id.toHexString());
+      const allBreaks = eventIds.length > 0 ? await findBreaksForEvents(eventIds) : [];
+      const breaksByEventId = new Map<string, typeof allBreaks>();
+      for (const b of allBreaks) {
+        const arr = breaksByEventId.get(b.clockEventId) ?? [];
+        arr.push(b);
+        breaksByEventId.set(b.clockEventId, arr);
+      }
+
+      // Gather user info
+      const validIds = allMemberIds.filter((id) => /^[0-9a-f]{24}$/i.test(id));
+      const [users, profiles] = await Promise.all([
+        usersCollection()
+          .find({ _id: { $in: validIds.map((id) => new ObjectId(id)) } })
+          .project<{ _id: ObjectId; name: string; image: string | null }>({ _id: 1, name: 1, image: 1 })
+          .toArray(),
+        profilesCollection()
+          .find({ userId: { $in: allMemberIds }, app: "timeharbor" })
+          .project<{ userId: string; displayName: string; avatar: string | null }>({
+            userId: 1,
+            displayName: 1,
+            avatar: 1,
+          })
+          .toArray(),
+      ]);
+
+      const userMap = new Map(users.map((u) => [u._id.toHexString(), u]));
+      const profileMap = new Map(profiles.map((p) => [p.userId, p]));
+
+      // Group clock events by userId
+      const eventsByUser = new Map<string, typeof clockEvents>();
+      for (const ev of clockEvents) {
+        if (!eventsByUser.has(ev.userId)) eventsByUser.set(ev.userId, []);
+        eventsByUser.get(ev.userId)!.push(ev);
+      }
+
+      const members = allMemberIds.map((userId) => {
+        const profile = profileMap.get(userId);
+        const userDoc = userMap.get(userId);
+        const name = profile?.displayName || userDoc?.name || "Unknown";
+        const image = profile?.avatar ?? userDoc?.image ?? null;
+
+        const userEvents = eventsByUser.get(userId) ?? [];
+        const activeEvent = userEvents.find((e) => e.endTime === null) ?? null;
+        const isClockedIn = activeEvent !== null;
+        const activeBreaks = activeEvent
+          ? (breaksByEventId.get(activeEvent._id.toHexString()) ?? [])
+          : [];
+        const isOnBreak = activeBreaks.some((b) => b.endTime === null);
+
+        // Sum today's break-adjusted work seconds (matches timesheet logic)
+        let todaySeconds = 0;
+        for (const ev of userEvents) {
+          const breaks = breaksByEventId.get(ev._id.toHexString()) ?? [];
+          todaySeconds += computeWorkSeconds(ev, breaks, now);
+        }
+
+        return {
+          userId,
+          name,
+          image,
+          isClockedIn,
+          isOnBreak,
+          activeClockStart: activeEvent?.startTime ?? null,
+          todaySeconds,
+        };
+      });
+
+      return reply.send({ members });
+    }
   );
 
   // GET /v1/clock/events — all events for current user

--- a/backend/src/routes/clock.ts
+++ b/backend/src/routes/clock.ts
@@ -249,15 +249,46 @@ export async function clockRoutes(app: FastifyInstance) {
       onRequest: [requireAuth],
       schema: {
         tags: ["Clock"],
+        querystring: {
+          type: "object",
+          properties: {
+            userId: { type: "string", description: "User ID (admin-only)" },
+          },
+        },
         response: {
           200: {
             type: "object",
             properties: { event: { ...clockEventShape, nullable: true } },
           },
+          403: { type: "object", properties: { error: { type: "string" } } },
         },
       },
     },
-    clockController.getActive
+    async (req, reply) => {
+      const { id: requestingUserId } = (req as any).user;
+      const { userId: targetUserId } = req.query as { userId?: string };
+
+      // If userId is provided, verify admin permission
+      const userId = targetUserId || requestingUserId;
+      if (targetUserId && targetUserId !== requestingUserId) {
+        const sharedAdminTeams = await teamsCollection()
+          .find({
+            admins: requestingUserId,
+            $or: [{ members: targetUserId }, { admins: targetUserId }],
+          })
+          .toArray();
+
+        if (sharedAdminTeams.length === 0) {
+          return reply.status(403).send({ error: "Forbidden" });
+        }
+      }
+
+      // Get the active clock event for the resolved userId
+      const event = await clockService.getActiveForUser(userId);
+      const breaks = event ? await findBreaksForEvents([event._id.toHexString()]) : [];
+      const publicEvent = event ? toPublicClockEvent(event, breaks) : null;
+      return reply.send({ event: publicEvent });
+    }
   );
 
   // GET /v1/clock/team-status?teamId=xxx — active clock events for all team members + today's hours

--- a/backend/src/routes/timers.ts
+++ b/backend/src/routes/timers.ts
@@ -517,13 +517,33 @@ export async function timerRoutes(app: FastifyInstance) {
         summary: "List WorkItems for today (local time)",
         querystring: {
           type: "object",
-          properties: { tz: { type: "string", default: "UTC" } },
+          properties: {
+            tz: { type: "string", default: "UTC" },
+            userId: { type: "string", description: "User ID (admin-only)" },
+          },
         },
       },
     },
     async (req, reply) => {
-      const { id: userId } = (req as any).user;
-      const { tz = "UTC" } = req.query as { tz?: string };
+      const { id: requestingUserId } = (req as any).user;
+      const { tz = "UTC", userId: targetUserId } = req.query as { tz?: string; userId?: string };
+
+      // If userId is provided, verify admin permission
+      const userId = targetUserId || requestingUserId;
+      if (targetUserId && targetUserId !== requestingUserId) {
+        const { teamsCollection } = await import("../models/index.js");
+        const sharedAdminTeams = await teamsCollection()
+          .find({
+            admins: requestingUserId,
+            $or: [{ members: targetUserId }, { admins: targetUserId }],
+          })
+          .toArray();
+
+        if (sharedAdminTeams.length === 0) {
+          return reply.status(403).send({ error: "Forbidden" });
+        }
+      }
+
       const today = toUtcDateKey(Date.now());
       const entries = await timerService.getDayEntries(userId, today, tz);
 

--- a/backend/src/routes/timers.ts
+++ b/backend/src/routes/timers.ts
@@ -192,7 +192,7 @@ export async function timerRoutes(app: FastifyInstance) {
         startNow?: boolean;
       };
 
-      const entryResult = await timerService.getOrCreateEntry(userId, ticketId, date);
+      const entryResult = await timerService.createEntry(userId, ticketId, date);
       if (entryResult === "not-found") return reply.status(404).send({ error: "Ticket not found" });
       if (entryResult === "forbidden") return reply.status(403).send({ error: "Forbidden" });
 

--- a/backend/src/routes/timers.ts
+++ b/backend/src/routes/timers.ts
@@ -457,7 +457,57 @@ export async function timerRoutes(app: FastifyInstance) {
     }
   );
 
-  // GET /v1/timers/today?tz= — shorthand for today's day view
+  // GET /v1/timers/team-running?teamId=xxx — running timers for all team members
+  app.get(
+    "/timers/team-running",
+    {
+      preHandler: [requireAuth],
+      schema: {
+        tags: ["Timers"],
+        summary: "Get all running timers for members of a team",
+        querystring: {
+          type: "object",
+          required: ["teamId"],
+          properties: { teamId: { type: "string" } },
+        },
+        response: {
+          200: {
+            type: "object",
+            properties: {
+              timers: {
+                type: "array",
+                items: {
+                  type: "object",
+                  properties: {
+                    timerId: { type: "string" },
+                    workItemId: { type: "string" },
+                    userId: { type: "string" },
+                    userName: { type: "string" },
+                    userImage: { type: "string", nullable: true },
+                    ticketId: { type: "string" },
+                    ticketTitle: { type: "string" },
+                    startTime: { type: "number" },
+                  },
+                },
+              },
+            },
+          },
+          403: err("Forbidden"),
+          404: err("Team not found"),
+        },
+      },
+    },
+    async (req, reply) => {
+      const { id: userId } = (req as any).user;
+      const { teamId } = req.query as { teamId: string };
+      const result = await timerService.getTeamRunningTimers(userId, teamId);
+      if (result === "not-found") return reply.code(404).send({ error: "Team not found" });
+      if (result === "forbidden") return reply.code(403).send({ error: "Forbidden" });
+      return reply.send({ timers: result });
+    }
+  );
+
+
   app.get(
     "/timers/today",
     {

--- a/backend/src/routes/timers.ts
+++ b/backend/src/routes/timers.ts
@@ -507,7 +507,6 @@ export async function timerRoutes(app: FastifyInstance) {
     }
   );
 
-
   app.get(
     "/timers/today",
     {

--- a/backend/src/routes/timers.ts
+++ b/backend/src/routes/timers.ts
@@ -192,7 +192,7 @@ export async function timerRoutes(app: FastifyInstance) {
         startNow?: boolean;
       };
 
-      const entryResult = await timerService.createEntry(userId, ticketId, date);
+      const entryResult = await timerService.getOrCreateEntry(userId, ticketId, date);
       if (entryResult === "not-found") return reply.status(404).send({ error: "Ticket not found" });
       if (entryResult === "forbidden") return reply.status(403).send({ error: "Forbidden" });
 

--- a/backend/src/services/clock.service.ts
+++ b/backend/src/services/clock.service.ts
@@ -522,6 +522,14 @@ export class ClockService {
     const updatedBreaks: ClockBreakInterval[] = breaks.map((b) =>
       b._id.equals(openBreak._id) ? { ...b, endTime: now, ...classification } : b
     );
+
+    // Restart the timer that was stopped when the break began
+    const breakStartTime = openBreak.startTime;
+    const closedTimer = await timerService.findClosedAtTime(event.userId, breakStartTime);
+    if (closedTimer) {
+      await timerService.restartTimerForWorkItem(event.userId, closedTimer.workItemId, now);
+    }
+
     const pub = toPublicClockEvent(event, updatedBreaks);
     broadcast(teamId, pub);
     return pub;

--- a/backend/src/services/timer.service.ts
+++ b/backend/src/services/timer.service.ts
@@ -109,19 +109,21 @@ export class TimerService {
       "A team member";
 
     await Promise.all(
-      team.admins.map((adminId) =>
-        notificationService.create({
-          userId: adminId,
-          title: "Timesheet Update",
-          body: `${actorName} has ${action} a timesheet entry for ${date} in ${team.name}`,
-          notificationData: {
-            type: "timesheet-entry-changed",
-            ticketId,
-            date,
-            teamId: ticket.teamId,
-          },
-        })
-      )
+      team.admins
+        .filter((adminId) => adminId !== actorUserId)
+        .map((adminId) =>
+          notificationService.create({
+            userId: adminId,
+            title: "Timesheet Update",
+            body: `${actorName} has ${action} a timesheet entry for ${date} in ${team.name}`,
+            notificationData: {
+              type: "timesheet-entry-changed",
+              ticketId,
+              date,
+              teamId: ticket.teamId,
+            },
+          })
+        )
     );
   }
 
@@ -164,6 +166,7 @@ export class TimerService {
 
   /**
    * Find or create a WorkItem for { userId, ticketId, date }.
+   * Does NOT notify admins — used internally when auto-creating entries on timer start.
    * Returns "not-found" if the ticket does not exist or "forbidden" if the user
    * is not a member of the ticket's team.
    */
@@ -397,6 +400,32 @@ export class TimerService {
   /** Close the currently running timer for a user and return its session id. */
   async closeRunningForUser(userId: string, now: number): Promise<string | null> {
     return this._closeRunningSession(userId, now);
+  }
+
+  /** Find the most recent timer for a user that was closed at exactly the given timestamp. */
+  async findClosedAtTime(userId: string, endTime: number): Promise<Timer | null> {
+    return timersCollection().findOne({ userId, endTime });
+  }
+
+  /**
+   * Start a new timer for an existing workItem.
+   * Does not close other running timers — caller is responsible for ensuring none exist.
+   */
+  async restartTimerForWorkItem(userId: string, workItemId: string, now: number): Promise<Timer | null> {
+    const workItem = await workItemsCollection().findOne({ _id: new ObjectId(workItemId) });
+    if (!workItem) return null;
+    const session: Timer = {
+      _id: new ObjectId(),
+      workItemId,
+      userId,
+      date: workItem.date,
+      startTime: now,
+      endTime: null,
+      createdAt: new Date(),
+    };
+    await timersCollection().insertOne(session);
+    broadcastTimerUpdate(userId);
+    return session;
   }
 
   /** Read a timer session by id, or null if missing/invalid. */
@@ -709,6 +738,100 @@ export class TimerService {
     }
 
     return created;
+  }
+
+  /**
+   * Return all running timers for members of a given team, enriched with
+   * ticket title and the user's display name.
+   * Verifies the requesting user is a member or admin of the team.
+   */
+  async getTeamRunningTimers(
+    requestingUserId: string,
+    teamId: string
+  ): Promise<
+    | "not-found"
+    | "forbidden"
+    | Array<{
+        timerId: string;
+        workItemId: string;
+        userId: string;
+        userName: string;
+        userImage: string | null;
+        ticketId: string;
+        ticketTitle: string;
+        startTime: number;
+      }>
+  > {
+    if (!isValidId(teamId)) return "not-found";
+
+    const team = await teamsCollection().findOne({ _id: new ObjectId(teamId) });
+    if (!team) return "not-found";
+
+    const allMembers = Array.from(new Set([...team.members, ...team.admins]));
+    if (!allMembers.includes(requestingUserId)) return "forbidden";
+
+    // 1. Tickets belonging to this team
+    const tickets = await ticketsCollection()
+      .find({ teamId })
+      .project<{ _id: ObjectId; title: string }>({ _id: 1, title: 1 })
+      .toArray();
+    const ticketMap = new Map(tickets.map((t) => [t._id.toHexString(), t.title]));
+    const ticketIds = [...ticketMap.keys()];
+
+    if (ticketIds.length === 0) return [];
+
+    // 2. Running work items for those tickets whose owner is a team member
+    const runningWorkItems = await workItemsCollection()
+      .find({ ticketId: { $in: ticketIds }, userId: { $in: allMembers } })
+      .toArray();
+    const workItemIds = runningWorkItems.map((wi) => wi._id.toHexString());
+
+    if (workItemIds.length === 0) return [];
+
+    // 3. Running timer sessions for those work items
+    const runningTimers = await timersCollection()
+      .find({ workItemId: { $in: workItemIds }, endTime: null })
+      .toArray();
+
+    if (runningTimers.length === 0) return [];
+
+    // 4. Enrich with user display info
+    const userIds = [...new Set(runningTimers.map((t) => t.userId))];
+    const [users, profiles] = await Promise.all([
+      usersCollection()
+        .find({ _id: { $in: userIds.filter(isValidId).map((id) => new ObjectId(id)) } })
+        .project<{ _id: ObjectId; name: string; image: string | null }>({ _id: 1, name: 1, image: 1 })
+        .toArray(),
+      profilesCollection()
+        .find({ userId: { $in: userIds }, app: "timeharbor" })
+        .project<{ userId: string; displayName: string; avatar: string | null }>({
+          userId: 1,
+          displayName: 1,
+          avatar: 1,
+        })
+        .toArray(),
+    ]);
+
+    const userNameMap = new Map(users.map((u) => [u._id.toHexString(), u.name]));
+    const profileMap = new Map(profiles.map((p) => [p.userId, p]));
+    const workItemMap = new Map(runningWorkItems.map((wi) => [wi._id.toHexString(), wi]));
+
+    return runningTimers.map((timer) => {
+      const workItem = workItemMap.get(timer.workItemId);
+      const profile = profileMap.get(timer.userId);
+      const userName = profile?.displayName || userNameMap.get(timer.userId) || "Unknown";
+      const userImage = profile?.avatar ?? null;
+      return {
+        timerId: timer._id.toHexString(),
+        workItemId: timer.workItemId,
+        userId: timer.userId,
+        userName,
+        userImage,
+        ticketId: workItem?.ticketId ?? "",
+        ticketTitle: workItem ? (ticketMap.get(workItem.ticketId) ?? workItem.ticketId) : "",
+        startTime: timer.startTime,
+      };
+    });
   }
 
   // ─── Private helpers ────────────────────────────────────────────────────────

--- a/backend/src/services/timer.service.ts
+++ b/backend/src/services/timer.service.ts
@@ -411,7 +411,11 @@ export class TimerService {
    * Start a new timer for an existing workItem.
    * Does not close other running timers — caller is responsible for ensuring none exist.
    */
-  async restartTimerForWorkItem(userId: string, workItemId: string, now: number): Promise<Timer | null> {
+  async restartTimerForWorkItem(
+    userId: string,
+    workItemId: string,
+    now: number
+  ): Promise<Timer | null> {
     const workItem = await workItemsCollection().findOne({ _id: new ObjectId(workItemId) });
     if (!workItem) return null;
     const session: Timer = {
@@ -800,7 +804,11 @@ export class TimerService {
     const [users, profiles] = await Promise.all([
       usersCollection()
         .find({ _id: { $in: userIds.filter(isValidId).map((id) => new ObjectId(id)) } })
-        .project<{ _id: ObjectId; name: string; image: string | null }>({ _id: 1, name: 1, image: 1 })
+        .project<{ _id: ObjectId; name: string; image: string | null }>({
+          _id: 1,
+          name: 1,
+          image: 1,
+        })
         .toArray(),
       profilesCollection()
         .find({ userId: { $in: userIds }, app: "timeharbor" })

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -1,18 +1,20 @@
 /**
- * DashboardPage — Overview of the user's workspace.
+ * DashboardPage — Team overview dashboard (mobile-first, scrollable).
  *
- * Shows:
- *   • Quick stats: Today's hours, Week hours, Active sessions, Teams
- *   • Team selector
- *   • Active clock session (if any)
- *   • Recent activity (last 5 clock events)
- *   • First-time user welcome cards (if no teams or events)
+ * Sections (stacked vertically for Capacitor):
+ *   1. Quick stats: Hours today, Open tickets, Closed today, High priority
+ *   2. Team members: Online/offline, clocked-in status, today's hours
+ *   3. Active tickets: Only tickets with running timers, with the person who started each
+ *   4. Time logged today: Per-member bar with hours
  */
 import {
   faClock,
+  faTicket,
+  faCheckCircle,
+  faExclamationTriangle,
+  faCircle,
   faPlay,
   faUsers,
-  faCalendarWeek,
   faArrowRight,
   faPlus,
   faRightToBracket,
@@ -31,39 +33,22 @@ import {
   Spinner,
   Text,
 } from '@mieweb/ui';
-import React, { useEffect, useMemo, useState } from 'react';
+import React, { useCallback, useEffect, useState } from 'react';
 
-import { clockApi, type ClockEvent } from '../../lib/api';
+import {
+  ticketApi,
+  type Ticket,
+  teamDashboardApi,
+  type TeamMemberClockStatus,
+  type TeamRunningTimer,
+} from '../../lib/api';
 import { useSession } from '../../lib/useSession';
 import { useTeam } from '../../lib/TeamContext';
 import { useRefresh } from '../../lib/RefreshContext';
-import { formatDuration, formatTime, formatDate, startOfDay } from '../../lib/timeUtils';
+import { formatDuration, formatTimer } from '../../lib/timeUtils';
 import { useRouter } from '../../ui/router';
 import { AppPage } from '../../ui/AppPage';
-
-// ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function getSessionWorkSeconds(event: ClockEvent, now: number): number {
-  // For completed sessions, prefer accumulatedTime (break-excluded) then fall back
-  if (event.endTime !== null) {
-    if (event.accumulatedTime > 0) return event.accumulatedTime;
-    return Math.max(0, Math.floor((event.endTime - event.startTime) / 1000));
-  }
-  // For active sessions
-  if (typeof event.workSeconds === 'number') return Math.max(0, event.workSeconds);
-  const accumulated = Math.max(0, event.accumulatedTime ?? 0);
-  if (event.isPaused) return accumulated;
-  return accumulated + Math.max(0, Math.floor((now - event.startTime) / 1000));
-}
-
-function computeHours(events: ClockEvent[], after: number, now: number): number {
-  let total = 0;
-  for (const e of events) {
-    if (e.startTime < after) continue;
-    total += getSessionWorkSeconds(e, now);
-  }
-  return total;
-}
+import { UserAvatar } from '../../ui/UserAvatar';
 
 // ─── DashboardPage ────────────────────────────────────────────────────────────
 
@@ -72,57 +57,75 @@ export const DashboardPage: React.FC = () => {
   const { navigate } = useRouter();
   const { teams, teamsReady, activeClockEvent, currentTime, selectedTeamId } = useTeam();
 
-  // All user clock events (from timecore REST)
-  const [allEvents, setAllEvents] = useState<ClockEvent[]>([]);
+  const selectedTeam = teams.find((t) => t.id === selectedTeamId) ?? null;
+  const teamAdminIds = new Set(selectedTeam?.admins ?? []);
+
+  const [tickets, setTickets] = useState<Ticket[]>([]);
+  const [memberStatuses, setMemberStatuses] = useState<TeamMemberClockStatus[]>([]);
+  const [runningTimers, setRunningTimers] = useState<TeamRunningTimer[]>([]);
+  const [loading, setLoading] = useState(false);
+
+  const isPersonalTeam =
+    !selectedTeamId || (teams.find((t) => t.id === selectedTeamId)?.isPersonal ?? true);
+
+  const fetchData = useCallback(async () => {
+    if (!user || !selectedTeamId) return;
+    setLoading(true);
+    try {
+      const [t, m, r] = await Promise.all([
+        ticketApi.getTickets(selectedTeamId).catch(() => [] as Ticket[]),
+        teamDashboardApi.getTeamClockStatus(selectedTeamId).catch(() => [] as TeamMemberClockStatus[]),
+        teamDashboardApi.getTeamRunningTimers(selectedTeamId).catch(() => [] as TeamRunningTimer[]),
+      ]);
+      setTickets(t);
+      setMemberStatuses(m);
+      setRunningTimers(r);
+    } finally {
+      setLoading(false);
+    }
+  }, [user, selectedTeamId]);
+
   useEffect(() => {
-    if (!user) return;
-    clockApi
-      .getEvents()
-      .then(setAllEvents)
-      .catch(() => setAllEvents([]));
-  }, [user]);
+    fetchData();
+  }, [fetchData]);
 
-  // Pull-to-refresh
-  useRefresh(
-    React.useCallback(async () => {
-      if (!user) return;
-      await clockApi
-        .getEvents()
-        .then(setAllEvents)
-        .catch(() => {});
-    }, [user]),
-  );
+  useRefresh(fetchData);
 
-  // Filter events to the selected team
-  const teamEvents = useMemo(
-    () => (selectedTeamId ? allEvents.filter((e) => e.teamId === selectedTeamId) : allEvents),
-    [allEvents, selectedTeamId],
-  );
+  // ─── Derived stats ───────────────────────────────────────────────────────────
 
-  // Compute stats
-  const todayStart = useMemo(() => startOfDay(new Date()).getTime(), []);
-  const weekStart = useMemo(() => {
-    const d = new Date();
-    d.setDate(d.getDate() - d.getDay());
-    d.setHours(0, 0, 0, 0);
-    return d.getTime();
-  }, []);
+  const openTickets = tickets.filter((t) => t.status !== 'closed' && t.status !== 'done');
+  const closedToday = tickets.filter((t) => {
+    if (t.status !== 'closed' && t.status !== 'done') return false;
+    if (!t.updatedAt) return false;
+    const updated = new Date(t.updatedAt);
+    const today = new Date();
+    return (
+      updated.getFullYear() === today.getFullYear() &&
+      updated.getMonth() === today.getMonth() &&
+      updated.getDate() === today.getDate()
+    );
+  });
+  const highPriority = tickets.filter((t) => t.priority === 'high' || t.priority === 'urgent');
+  const overdue = highPriority.filter((t) => t.status !== 'closed' && t.status !== 'done');
+  const unassignedOpen = openTickets.filter((t) => !t.assignedTo);
 
-  const todayHours = useMemo(
-    () => computeHours(teamEvents, todayStart, currentTime),
-    [teamEvents, todayStart, currentTime],
-  );
+  const todayTotalSeconds = memberStatuses.reduce((sum, m) => sum + m.todaySeconds, 0);
+  const membersClocked = memberStatuses.filter((m) => m.isClockedIn);
 
-  const weekHours = useMemo(
-    () => computeHours(teamEvents, weekStart, currentTime),
-    [teamEvents, weekStart, currentTime],
-  );
+  // Sort members: admins first, then clocked-in, then by hours
+  const sortedMembers = [...memberStatuses].sort((a, b) => {
+    const aIsAdmin = teamAdminIds.has(a.userId);
+    const bIsAdmin = teamAdminIds.has(b.userId);
+    if (aIsAdmin && !bIsAdmin) return -1;
+    if (!aIsAdmin && bIsAdmin) return 1;
+    if (a.isClockedIn && !b.isClockedIn) return -1;
+    if (!a.isClockedIn && b.isClockedIn) return 1;
+    return b.todaySeconds - a.todaySeconds;
+  });
 
-  const activeSessions = useMemo(() => teamEvents.filter((e) => !e.endTime).length, [teamEvents]);
+  const maxMemberSeconds = Math.max(...memberStatuses.map((m) => m.todaySeconds), 1);
 
-  const recentEvents = useMemo(() => teamEvents.filter((e) => e.endTime).slice(0, 5), [teamEvents]);
-
-  const isFirstTime = teams.length <= 1 && teamEvents.length === 0;
+  const isFirstTime = teams.length <= 1 && teams.every((t) => t.isPersonal);
 
   if (!teamsReady) {
     return (
@@ -134,7 +137,7 @@ export const DashboardPage: React.FC = () => {
 
   return (
     <AppPage>
-      {/* First time user welcome */}
+      {/* ── First-time welcome ──────────────────────────────────────────── */}
       {isFirstTime && (
         <Card variant="outlined" padding="lg" className="text-center">
           <CardContent>
@@ -171,73 +174,7 @@ export const DashboardPage: React.FC = () => {
         </Card>
       )}
 
-      {/* Quick stats */}
-      <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
-        <Card padding="sm">
-          <CardContent className="flex items-center gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400">
-              <FontAwesomeIcon icon={faClock} className="text-sm" />
-            </div>
-            <div>
-              <Text variant="muted" size="xs">
-                Today
-              </Text>
-              <Text size="lg" weight="semibold" data-testid="stat-today">
-                {formatDuration(todayHours)}
-              </Text>
-            </div>
-          </CardContent>
-        </Card>
-        <Card padding="sm">
-          <CardContent className="flex items-center gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600 dark:bg-violet-950/50 dark:text-violet-400">
-              <FontAwesomeIcon icon={faCalendarWeek} className="text-sm" />
-            </div>
-            <div>
-              <Text variant="muted" size="xs">
-                This Week
-              </Text>
-              <Text size="lg" weight="semibold" data-testid="stat-week">
-                {formatDuration(weekHours)}
-              </Text>
-            </div>
-          </CardContent>
-        </Card>
-        <Card padding="sm">
-          <CardContent className="flex items-center gap-3">
-            <div
-              className={`flex h-10 w-10 shrink-0 items-center justify-center rounded-lg ${activeSessions > 0 ? 'bg-green-50 text-green-600 dark:bg-green-950/50 dark:text-green-400' : 'bg-neutral-100 text-neutral-500 dark:bg-neutral-800 dark:text-neutral-400'}`}
-            >
-              <FontAwesomeIcon icon={faPlay} className="text-sm" />
-            </div>
-            <div>
-              <Text variant="muted" size="xs">
-                Active
-              </Text>
-              <Text size="lg" weight="semibold">
-                {String(activeSessions)}
-              </Text>
-            </div>
-          </CardContent>
-        </Card>
-        <Card padding="sm">
-          <CardContent className="flex items-center gap-3">
-            <div className="flex h-10 w-10 shrink-0 items-center justify-center rounded-lg bg-amber-50 text-amber-600 dark:bg-amber-950/50 dark:text-amber-400">
-              <FontAwesomeIcon icon={faUsers} className="text-sm" />
-            </div>
-            <div>
-              <Text variant="muted" size="xs">
-                Teams
-              </Text>
-              <Text size="lg" weight="semibold">
-                {String(teams.filter((t) => !t.isPersonal).length)}
-              </Text>
-            </div>
-          </CardContent>
-        </Card>
-      </div>
-
-      {/* Active session banner */}
+      {/* ── Active session banner ───────────────────────────────────────── */}
       {activeClockEvent && (
         <Alert variant="success">
           <AlertTitle>
@@ -247,8 +184,7 @@ export const DashboardPage: React.FC = () => {
             </span>
           </AlertTitle>
           <AlertDescription>
-            Started {formatTime(new Date(activeClockEvent.startTime))} •{' '}
-            {formatDuration(Math.floor((currentTime - activeClockEvent.startTime) / 1000))}
+            {formatTimer(Math.floor((currentTime - activeClockEvent.startTime) / 1000))} elapsed
           </AlertDescription>
           <Button
             variant="primary"
@@ -262,43 +198,352 @@ export const DashboardPage: React.FC = () => {
         </Alert>
       )}
 
-      {/* Recent Activity */}
-      {recentEvents.length > 0 && (
+      {/* ── Quick stats ─────────────────────────────────────────────────── */}
+      <div className="grid grid-cols-2 gap-3">
+        {/* Hours today */}
+        <Card padding="sm">
+          <CardContent className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-blue-50 text-blue-600 dark:bg-blue-950/50 dark:text-blue-400">
+              <FontAwesomeIcon icon={faClock} className="text-sm" />
+            </div>
+            <div>
+              <Text variant="muted" size="xs">
+                Hours today
+              </Text>
+              <Text size="lg" weight="semibold">
+                {(todayTotalSeconds / 3600).toFixed(1)}
+              </Text>
+              {membersClocked.length > 0 && (
+                <Text
+                  variant="muted"
+                  size="xs"
+                  className="mt-0.5 text-green-600 dark:text-green-400"
+                >
+                  ↑ {membersClocked.length} active
+                </Text>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Open tickets */}
+        <Card padding="sm">
+          <CardContent className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-violet-50 text-violet-600 dark:bg-violet-950/50 dark:text-violet-400">
+              <FontAwesomeIcon icon={faTicket} className="text-sm" />
+            </div>
+            <div>
+              <Text variant="muted" size="xs">
+                Open tickets
+              </Text>
+              <Text size="lg" weight="semibold">
+                {String(openTickets.length)}
+              </Text>
+              {unassignedOpen.length > 0 && (
+                <Text variant="muted" size="xs" className="mt-0.5">
+                  {unassignedOpen.length} unassigned
+                </Text>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* Closed today */}
+        <Card padding="sm">
+          <CardContent className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-green-50 text-green-600 dark:bg-green-950/50 dark:text-green-400">
+              <FontAwesomeIcon icon={faCheckCircle} className="text-sm" />
+            </div>
+            <div>
+              <Text variant="muted" size="xs">
+                Closed today
+              </Text>
+              <Text size="lg" weight="semibold">
+                {String(closedToday.length)}
+              </Text>
+            </div>
+          </CardContent>
+        </Card>
+
+        {/* High priority */}
+        <Card padding="sm">
+          <CardContent className="flex items-start gap-3">
+            <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-lg bg-red-50 text-red-600 dark:bg-red-950/50 dark:text-red-400">
+              <FontAwesomeIcon icon={faExclamationTriangle} className="text-sm" />
+            </div>
+            <div>
+              <Text variant="muted" size="xs">
+                High priority
+              </Text>
+              <Text size="lg" weight="semibold" className="text-red-600 dark:text-red-400">
+                {String(highPriority.filter((t) => t.status !== 'closed' && t.status !== 'done').length)}
+              </Text>
+              {overdue.length > 0 && (
+                <Text variant="muted" size="xs" className="mt-0.5">
+                  {overdue.length} overdue
+                </Text>
+              )}
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+
+      {/* ── Team members ─────────────────────────────────────────────────── */}
+      {!isPersonalTeam && (
         <Card padding="none">
           <CardHeader className="flex flex-row items-center justify-between px-5 py-3">
-            <CardTitle className="text-sm">Recent Activity</CardTitle>
-            <Button variant="link" size="sm" onClick={() => navigate('/app/timesheet')}>
-              View all →
-            </Button>
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <FontAwesomeIcon icon={faUsers} className="text-neutral-400" />
+              Team
+            </CardTitle>
+            {loading && <Spinner size="sm" />}
           </CardHeader>
           <CardContent className="p-0">
-            <ul className="divide-y divide-neutral-100 dark:divide-neutral-800">
-              {recentEvents.map((event) => {
-                const start = new Date(event.startTime);
-                const end = event.endTime ? new Date(event.endTime) : null;
-                const durSec = end ? (end.getTime() - event.startTime) / 1000 : 0;
-                const team = teams.find((t) => t.id === event.teamId);
-                return (
-                  <li key={event.id} className="flex items-center justify-between px-5 py-3">
-                    <div className="min-w-0">
-                      <Text size="sm" weight="medium">
-                        {formatDate(start)} • {formatTime(start)}
-                        {end ? ` – ${formatTime(end)}` : ''}
-                      </Text>
-                      <Text variant="muted" size="xs" className="mt-0.5">
-                        {team?.isPersonal ? 'Personal' : (team?.name ?? 'Unknown')}
+            {sortedMembers.length === 0 ? (
+              <div className="px-5 py-4 text-center">
+                <Text variant="muted" size="sm">
+                  No members found
+                </Text>
+              </div>
+            ) : (
+              <>
+                {membersClocked.length > 0 && (
+                  <div className="px-5 pb-1 pt-2">
+                    <Text
+                      variant="muted"
+                      size="xs"
+                      weight="medium"
+                      className="uppercase tracking-wide"
+                    >
+                      Online · {membersClocked.length}
+                    </Text>
+                  </div>
+                )}
+                <ul className="divide-y divide-neutral-100 dark:divide-neutral-800">
+                  {sortedMembers
+                    .filter((m) => m.isClockedIn)
+                    .map((member) => (
+                      <MemberRow
+                        key={member.userId}
+                        member={member}
+                        currentTime={currentTime}
+                        isAdmin={teamAdminIds.has(member.userId)}
+                      />
+                    ))}
+                </ul>
+                {sortedMembers.some((m) => !m.isClockedIn) && (
+                  <>
+                    <div className="px-5 pb-1 pt-3">
+                      <Text
+                        variant="muted"
+                        size="xs"
+                        weight="medium"
+                        className="uppercase tracking-wide"
+                      >
+                        Offline · {sortedMembers.filter((m) => !m.isClockedIn).length}
                       </Text>
                     </div>
-                    <Badge variant="secondary" size="sm">
-                      {formatDuration(durSec)}
-                    </Badge>
+                    <ul className="divide-y divide-neutral-100 dark:divide-neutral-800">
+                      {sortedMembers
+                        .filter((m) => !m.isClockedIn)
+                        .map((member) => (
+                          <MemberRow
+                            key={member.userId}
+                            member={member}
+                            currentTime={currentTime}
+                            isAdmin={teamAdminIds.has(member.userId)}
+                          />
+                        ))}
+                    </ul>
+                  </>
+                )}
+              </>
+            )}
+          </CardContent>
+        </Card>
+      )}
+
+      {/* ── Active tickets (with running timers) ─────────────────────────── */}
+      <Card padding="none">
+        <CardHeader className="flex flex-row items-center justify-between px-5 py-3">
+          <CardTitle className="flex items-center gap-2 text-sm">
+            <FontAwesomeIcon icon={faPlay} className="text-green-500" />
+            Active tickets
+            {runningTimers.length > 0 && (
+              <Badge variant="secondary" size="sm">
+                {runningTimers.length} running
+              </Badge>
+            )}
+          </CardTitle>
+          <Button variant="link" size="sm" onClick={() => navigate('/app/tickets')}>
+            View all →
+          </Button>
+        </CardHeader>
+        <CardContent className="p-0">
+          {loading ? (
+            <div className="flex justify-center py-6">
+              <Spinner size="sm" />
+            </div>
+          ) : runningTimers.length === 0 ? (
+            <div className="px-5 py-6 text-center">
+              <Text variant="muted" size="sm">
+                No active timers right now
+              </Text>
+            </div>
+          ) : (
+            <ul className="divide-y divide-neutral-100 dark:divide-neutral-800">
+              {runningTimers.map((timer) => {
+                const ticket = tickets.find((t) => t.id === timer.ticketId);
+                const elapsedSec = Math.floor((currentTime - timer.startTime) / 1000);
+                const priorityColor =
+                  ticket?.priority === 'high' || ticket?.priority === 'urgent'
+                    ? 'bg-red-100 text-red-700 dark:bg-red-950/40 dark:text-red-400'
+                    : ticket?.priority === 'medium'
+                      ? 'bg-amber-100 text-amber-700 dark:bg-amber-950/40 dark:text-amber-400'
+                      : 'bg-neutral-100 text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400';
+                return (
+                  <li key={timer.timerId} className="flex items-center gap-3 px-5 py-3">
+                    {ticket?.priority && (
+                      <span
+                        className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium capitalize ${priorityColor}`}
+                      >
+                        {ticket.priority === 'urgent' ? 'High' : ticket.priority.charAt(0).toUpperCase() + ticket.priority.slice(1)}
+                      </span>
+                    )}
+                    <div className="min-w-0 flex-1">
+                      <Text size="sm" weight="medium" className="truncate">
+                        {timer.ticketTitle}
+                      </Text>
+                      <div className="mt-0.5 flex items-center gap-1.5">
+                        <UserAvatar name={timer.userName} src={timer.userImage} size="xs" />
+                        <Text variant="muted" size="xs">
+                          {timer.userName}
+                        </Text>
+                      </div>
+                    </div>
+                    <div className="shrink-0 text-right">
+                      <Text size="xs" weight="medium" className="font-mono text-green-600 dark:text-green-400">
+                        {formatTimer(elapsedSec)}
+                      </Text>
+                    </div>
                   </li>
                 );
               })}
             </ul>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* ── Time logged today ────────────────────────────────────────────── */}
+      {!isPersonalTeam && memberStatuses.some((m) => m.todaySeconds > 0) && (
+        <Card padding="none">
+          <CardHeader className="flex flex-row items-center justify-between px-5 py-3">
+            <CardTitle className="flex items-center gap-2 text-sm">
+              <FontAwesomeIcon icon={faClock} className="text-neutral-400" />
+              Time logged today
+              <span className="ml-1 rounded-full bg-neutral-100 px-2 py-0.5 text-xs font-medium text-neutral-600 dark:bg-neutral-800 dark:text-neutral-400">
+                {(todayTotalSeconds / 3600).toFixed(1)}h total
+              </span>
+            </CardTitle>
+          </CardHeader>
+          <CardContent className="p-0">
+            <ul className="divide-y divide-neutral-100 dark:divide-neutral-800">
+              {sortedMembers
+                .filter((m) => m.todaySeconds > 0 || m.isClockedIn)
+                .map((member) => {
+                  const barPct = Math.round((member.todaySeconds / maxMemberSeconds) * 100);
+                  return (
+                    <li key={member.userId} className="flex items-center gap-3 px-5 py-3">
+                      <UserAvatar name={member.name} src={member.image} size="sm" />
+                      <div className="min-w-0 flex-1">
+                        <Text size="sm" weight="medium">
+                          {member.name.split(' ')[0]}{member.name.split(' ')[1] ? ` ${member.name.split(' ')[1][0]}.` : ''}
+                        </Text>
+                        <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
+                          <div
+                            className={`h-full rounded-full transition-all ${member.isClockedIn ? 'bg-blue-500' : 'bg-neutral-300 dark:bg-neutral-600'}`}
+                            style={{ width: `${barPct}%` }}
+                          />
+                        </div>
+                      </div>
+                      <Text size="sm" weight="medium" className="shrink-0 tabular-nums">
+                        {formatDuration(member.todaySeconds)}
+                      </Text>
+                      {member.isClockedIn && (
+                        <span className="h-2 w-2 shrink-0 animate-pulse rounded-full bg-green-500" />
+                      )}
+                    </li>
+                  );
+                })}
+            </ul>
+            <div className="border-t border-neutral-100 px-5 py-2 dark:border-neutral-800">
+              <Text variant="muted" size="xs">
+                {membersClocked.length} member{membersClocked.length !== 1 ? 's' : ''} currently
+                tracking
+              </Text>
+            </div>
           </CardContent>
         </Card>
       )}
     </AppPage>
+  );
+};
+
+// ─── MemberRow ────────────────────────────────────────────────────────────────
+
+interface MemberRowProps {
+  member: TeamMemberClockStatus;
+  currentTime: number;
+  isAdmin?: boolean;
+}
+
+const MemberRow: React.FC<MemberRowProps> = ({ member, currentTime, isAdmin }) => {
+  const sessionSeconds = member.isClockedIn && member.activeClockStart
+    ? Math.floor((currentTime - member.activeClockStart) / 1000)
+    : member.todaySeconds;
+
+  return (
+    <li className="flex items-center gap-3 px-5 py-3">
+      <div className="relative shrink-0">
+        <UserAvatar name={member.name} src={member.image} size="sm" />
+        <span
+          className={`absolute -bottom-0.5 -right-0.5 h-3 w-3 rounded-full border-2 border-white dark:border-neutral-900 ${
+            member.isClockedIn ? 'bg-green-500' : 'bg-neutral-300 dark:bg-neutral-600'
+          }`}
+          aria-hidden="true"
+        />
+      </div>
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-1.5">
+          <Text size="sm" weight="medium" className="truncate">
+            {member.name}
+          </Text>
+          {isAdmin && (
+            <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-violet-100 text-violet-700 dark:bg-violet-950/50 dark:text-violet-400">
+              Admin
+            </span>
+          )}
+          {member.isOnBreak && (
+            <span className="shrink-0 rounded px-1 py-0.5 text-[10px] font-semibold uppercase tracking-wide bg-amber-100 text-amber-700 dark:bg-amber-950/50 dark:text-amber-400">
+              On Break
+            </span>
+          )}
+        </div>
+        <Text variant="muted" size="xs">
+          {member.isClockedIn
+            ? member.isOnBreak
+              ? 'On break'
+              : 'Clocked in'
+            : member.todaySeconds > 0
+              ? 'Clocked out'
+              : 'Not tracked today'}
+        </Text>
+      </div>
+      {sessionSeconds > 0 && (
+        <Text size="sm" weight="medium" className="shrink-0 tabular-nums">
+          {formatDuration(sessionSeconds)}
+        </Text>
+      )}
+    </li>
   );
 };

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -12,7 +12,6 @@ import {
   faTicket,
   faCheckCircle,
   faExclamationTriangle,
-  faCircle,
   faPlay,
   faUsers,
   faArrowRight,

--- a/src/features/dashboard/DashboardPage.tsx
+++ b/src/features/dashboard/DashboardPage.tsx
@@ -73,7 +73,9 @@ export const DashboardPage: React.FC = () => {
     try {
       const [t, m, r] = await Promise.all([
         ticketApi.getTickets(selectedTeamId).catch(() => [] as Ticket[]),
-        teamDashboardApi.getTeamClockStatus(selectedTeamId).catch(() => [] as TeamMemberClockStatus[]),
+        teamDashboardApi
+          .getTeamClockStatus(selectedTeamId)
+          .catch(() => [] as TeamMemberClockStatus[]),
         teamDashboardApi.getTeamRunningTimers(selectedTeamId).catch(() => [] as TeamRunningTimer[]),
       ]);
       setTickets(t);
@@ -275,7 +277,9 @@ export const DashboardPage: React.FC = () => {
                 High priority
               </Text>
               <Text size="lg" weight="semibold" className="text-red-600 dark:text-red-400">
-                {String(highPriority.filter((t) => t.status !== 'closed' && t.status !== 'done').length)}
+                {String(
+                  highPriority.filter((t) => t.status !== 'closed' && t.status !== 'done').length,
+                )}
               </Text>
               {overdue.length > 0 && (
                 <Text variant="muted" size="xs" className="mt-0.5">
@@ -406,7 +410,9 @@ export const DashboardPage: React.FC = () => {
                       <span
                         className={`shrink-0 rounded px-1.5 py-0.5 text-xs font-medium capitalize ${priorityColor}`}
                       >
-                        {ticket.priority === 'urgent' ? 'High' : ticket.priority.charAt(0).toUpperCase() + ticket.priority.slice(1)}
+                        {ticket.priority === 'urgent'
+                          ? 'High'
+                          : ticket.priority.charAt(0).toUpperCase() + ticket.priority.slice(1)}
                       </span>
                     )}
                     <div className="min-w-0 flex-1">
@@ -421,7 +427,11 @@ export const DashboardPage: React.FC = () => {
                       </div>
                     </div>
                     <div className="shrink-0 text-right">
-                      <Text size="xs" weight="medium" className="font-mono text-green-600 dark:text-green-400">
+                      <Text
+                        size="xs"
+                        weight="medium"
+                        className="font-mono text-green-600 dark:text-green-400"
+                      >
                         {formatTimer(elapsedSec)}
                       </Text>
                     </div>
@@ -456,7 +466,8 @@ export const DashboardPage: React.FC = () => {
                       <UserAvatar name={member.name} src={member.image} size="sm" />
                       <div className="min-w-0 flex-1">
                         <Text size="sm" weight="medium">
-                          {member.name.split(' ')[0]}{member.name.split(' ')[1] ? ` ${member.name.split(' ')[1][0]}.` : ''}
+                          {member.name.split(' ')[0]}
+                          {member.name.split(' ')[1] ? ` ${member.name.split(' ')[1][0]}.` : ''}
                         </Text>
                         <div className="mt-1 h-1.5 w-full overflow-hidden rounded-full bg-neutral-100 dark:bg-neutral-800">
                           <div
@@ -497,9 +508,10 @@ interface MemberRowProps {
 }
 
 const MemberRow: React.FC<MemberRowProps> = ({ member, currentTime, isAdmin }) => {
-  const sessionSeconds = member.isClockedIn && member.activeClockStart
-    ? Math.floor((currentTime - member.activeClockStart) / 1000)
-    : member.todaySeconds;
+  const sessionSeconds =
+    member.isClockedIn && member.activeClockStart
+      ? Math.floor((currentTime - member.activeClockStart) / 1000)
+      : member.todaySeconds;
 
   return (
     <li className="flex items-center gap-3 px-5 py-3">

--- a/src/features/feedback/ReportIssueModal.tsx
+++ b/src/features/feedback/ReportIssueModal.tsx
@@ -20,11 +20,20 @@ interface ReportIssueModalProps {
 const ENV = (import.meta as { env?: Record<string, string> }).env ?? {};
 const API_KEY = ENV.VITE_POLLENATE_API_KEY || undefined;
 const INBOX_KEY = ENV.VITE_POLLENATE_BUGS_INBOX_KEY || undefined;
+const FEATURE_INBOX_KEY = ENV.VITE_POLLENATE_FEATURE_INBOX_KEY || undefined;
 const API_URL = 'https://api.pollenate.dev/collect';
+
+type IssueType = 'bug' | 'feature';
+
+const ISSUE_TYPES: { value: IssueType; label: string; emoji: string }[] = [
+  { value: 'bug', label: 'Bug', emoji: '🐛' },
+  { value: 'feature', label: 'Feature Request', emoji: '✨' },
+];
 
 export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClose }) => {
   const { user } = useSession();
   const [comment, setComment] = useState('');
+  const [issueType, setIssueType] = useState<IssueType>('bug');
   const [submitting, setSubmitting] = useState(false);
   const [submitted, setSubmitted] = useState(false);
   const [error, setError] = useState<string | null>(null);
@@ -32,6 +41,7 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
   useEffect(() => {
     if (open) {
       setComment('');
+      setIssueType('bug');
       setSubmitting(false);
       setSubmitted(false);
       setError(null);
@@ -53,7 +63,7 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
         method: 'POST',
         headers: { 'Content-Type': 'application/json', 'X-Pollenate-Key': API_KEY },
         body: JSON.stringify({
-          inboxKey: INBOX_KEY,
+          inboxKey: issueType === 'bug' ? INBOX_KEY : FEATURE_INBOX_KEY,
           type: 'text',
           comment: comment.trim(),
           context: {
@@ -61,6 +71,7 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
             ...(user?.name ? { userName: user.name } : {}),
             page: window.location.pathname,
             source: 'report-issue',
+            issueType, // 'bug' or 'feature' — used in GitHub issue label
           },
         }),
       });
@@ -77,7 +88,7 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
     } finally {
       setSubmitting(false);
     }
-  }, [comment, onClose, user]);
+  }, [comment, issueType, onClose, user]);
 
   return (
     <Modal open={open} onOpenChange={(isOpen) => !isOpen && onClose()} size="sm">
@@ -109,6 +120,32 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
           </p>
         ) : (
           <div className="flex flex-col gap-4">
+            {/* Issue Type Selector */}
+            <div className="flex flex-col gap-2">
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
+                Type
+              </p>
+              <div className="flex gap-2">
+                {ISSUE_TYPES.map(({ value, label, emoji }) => (
+                  <button
+                    key={value}
+                    type="button"
+                    onClick={() => setIssueType(value)}
+                    disabled={submitting}
+                    className={`flex flex-1 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors
+                      ${issueType === value
+                        ? 'border-amber-400 bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400'
+                        : 'border-neutral-300 bg-white text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400'
+                      }`}
+                  >
+                    <span>{emoji}</span>
+                    <span>{label}</span>
+                  </button>
+                ))}
+              </div>
+            </div>
+
+            {/* Comment */}
             <div className="flex flex-col gap-2">
               <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
                 Describe the issue

--- a/src/features/feedback/ReportIssueModal.tsx
+++ b/src/features/feedback/ReportIssueModal.tsx
@@ -122,9 +122,7 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
           <div className="flex flex-col gap-4">
             {/* Issue Type Selector */}
             <div className="flex flex-col gap-2">
-              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">
-                Type
-              </p>
+              <p className="text-sm font-medium text-neutral-700 dark:text-neutral-300">Type</p>
               <div className="flex gap-2">
                 {ISSUE_TYPES.map(({ value, label, emoji }) => (
                   <button
@@ -133,9 +131,10 @@ export const ReportIssueModal: React.FC<ReportIssueModalProps> = ({ open, onClos
                     onClick={() => setIssueType(value)}
                     disabled={submitting}
                     className={`flex flex-1 items-center justify-center gap-2 rounded-lg border px-3 py-2 text-sm font-medium transition-colors
-                      ${issueType === value
-                        ? 'border-amber-400 bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400'
-                        : 'border-neutral-300 bg-white text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400'
+                      ${
+                        issueType === value
+                          ? 'border-amber-400 bg-amber-50 text-amber-700 dark:bg-amber-900/20 dark:text-amber-400'
+                          : 'border-neutral-300 bg-white text-neutral-600 hover:border-neutral-400 dark:border-neutral-600 dark:bg-neutral-800 dark:text-neutral-400'
                       }`}
                   >
                     <span>{emoji}</span>

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -391,8 +391,10 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId, username }) =>
 
           {/* Work tab */}
           <TabsContent value="work" className="flex flex-col gap-4">
-            {/* Today's clock status — own profile only */}
-            {isOwn && <TodayStatusCard />}
+            {/* Today's clock status — own profile or admin viewing team member */}
+            {(isOwn || (profile.sharedTeams ?? []).some((t) => t.isAdmin)) && (
+              <TodayStatusCard userId={profile.id} />
+            )}
 
             {/* 48 h work summary */}
             <WorkSummaryTags userId={profile.id} />

--- a/src/features/timers/TodayStatusCard.tsx
+++ b/src/features/timers/TodayStatusCard.tsx
@@ -9,7 +9,14 @@ import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Badge, Card, CardContent, Text } from '@mieweb/ui';
 import { useCallback, useEffect, useState } from 'react';
 
-import { clockApi, timerApi, ticketApi, type ClockEvent, type DayEntry, type Ticket } from '../../lib/api';
+import {
+  clockApi,
+  timerApi,
+  ticketApi,
+  type ClockEvent,
+  type DayEntry,
+  type Ticket,
+} from '../../lib/api';
 import { useTeam } from '../../lib/TeamContext';
 import { useSession } from '../../lib/useSession';
 import {

--- a/src/features/timers/TodayStatusCard.tsx
+++ b/src/features/timers/TodayStatusCard.tsx
@@ -1,14 +1,17 @@
 /**
- * TodayStatusCard — shows the user's current clock-in status and active ticket.
+ * TodayStatusCard — shows a user's current clock-in status and active ticket.
  * Only rendered when the user is clocked in.
+ *
+ * @param userId - Optional user ID to show. Defaults to current logged-in user.
  */
 import { faClock, faPlay } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Badge, Card, CardContent, Text } from '@mieweb/ui';
 import { useCallback, useEffect, useState } from 'react';
 
-import { timerApi, ticketApi, type DayEntry, type Ticket } from '../../lib/api';
+import { clockApi, timerApi, ticketApi, type ClockEvent, type DayEntry, type Ticket } from '../../lib/api';
 import { useTeam } from '../../lib/TeamContext';
+import { useSession } from '../../lib/useSession';
 import {
   formatDuration,
   formatTime,
@@ -17,30 +20,63 @@ import {
 } from '../../lib/timeUtils';
 import { useRouter } from '../../ui/router';
 
-export function TodayStatusCard() {
-  const { activeClockEvent, currentTime } = useTeam();
+interface TodayStatusCardProps {
+  userId?: string;
+}
+
+export function TodayStatusCard({ userId: propUserId }: TodayStatusCardProps) {
+  const { user } = useSession();
+  const { activeClockEvent: ownClockEvent, currentTime } = useTeam();
   const { navigate } = useRouter();
   const [todayEntries, setTodayEntries] = useState<DayEntry[]>([]);
   const [runningTicket, setRunningTicket] = useState<Ticket | null>(null);
+  const [clockEvent, setClockEvent] = useState<ClockEvent | null>(null);
+
+  // If no userId prop, use current user
+  const userId = propUserId ?? user?.id;
+  const isOwn = userId === user?.id;
 
   const fetchToday = useCallback(() => {
+    if (!userId) return;
     timerApi
-      .getToday()
+      .getToday(isOwn ? undefined : userId)
       .then(setTodayEntries)
       .catch(() => {});
-  }, []);
+  }, [userId, isOwn]);
 
-  // Fetch on mount and whenever clock-in state changes
+  const fetchClockEvent = useCallback(() => {
+    if (!userId) return;
+    clockApi
+      .getActive(isOwn ? undefined : userId)
+      .then(setClockEvent)
+      .catch(() => setClockEvent(null));
+  }, [userId, isOwn]);
+
+  // Fetch on mount and whenever clock-in state changes (own profile only)
   useEffect(() => {
-    if (!activeClockEvent) return;
+    if (isOwn && !ownClockEvent) return;
     fetchToday();
-  }, [activeClockEvent, fetchToday]);
+    fetchClockEvent();
+  }, [ownClockEvent, fetchToday, fetchClockEvent, isOwn]);
+
+  // For non-own profiles, poll periodically
+  useEffect(() => {
+    if (isOwn) return;
+    fetchToday();
+    fetchClockEvent();
+    const interval = setInterval(() => {
+      fetchToday();
+      fetchClockEvent();
+    }, 15000); // Poll every 15 seconds
+    return () => clearInterval(interval);
+  }, [isOwn, fetchToday, fetchClockEvent]);
 
   // Re-fetch when timer mutations occur (WorkPage broadcasts this event)
   useEffect(() => {
+    if (!isOwn) return;
     window.addEventListener('work:refetch', fetchToday);
     return () => window.removeEventListener('work:refetch', fetchToday);
-  }, [fetchToday]);
+  }, [fetchToday, isOwn]);
 
   // Fetch full ticket when the running entry changes (needed for github field)
   useEffect(() => {
@@ -54,6 +90,9 @@ export function TodayStatusCard() {
       .then(setRunningTicket)
       .catch(() => setRunningTicket(null));
   }, [todayEntries]);
+
+  // Use fetched clock event for other users, or own from context
+  const activeClockEvent = isOwn ? ownClockEvent : clockEvent;
 
   // Not clocked in — hide card entirely
   if (!activeClockEvent) return null;

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -164,10 +164,10 @@ export const WorkPage: React.FC = () => {
   const [editError, setEditError] = useState<string | null>(null);
   const [editLoading, setEditLoading] = useState(false);
 
-  // ── Fetch tickets for all teams (for both pickers) ──
+  // ── Fetch tickets for selected team only ──
 
   useEffect(() => {
-    if (teams.length === 0) {
+    if (!selectedTeamId) {
       setAllTickets([]);
       return;
     }
@@ -176,17 +176,9 @@ export const WorkPage: React.FC = () => {
 
     const loadTickets = async () => {
       try {
-        const ticketLists = await Promise.all(teams.map((team) => ticketApi.getTickets(team.id)));
+        const tickets = await ticketApi.getTickets(selectedTeamId);
         if (cancelled) return;
-
-        const byId = new Map<string, Ticket>();
-        for (const tickets of ticketLists) {
-          for (const ticket of tickets) {
-            byId.set(ticket.id, ticket);
-          }
-        }
-
-        setAllTickets(Array.from(byId.values()));
+        setAllTickets(tickets);
       } catch {
         if (!cancelled) setAllTickets([]);
       }
@@ -197,7 +189,7 @@ export const WorkPage: React.FC = () => {
     return () => {
       cancelled = true;
     };
-  }, [teams]);
+  }, [selectedTeamId]);
 
   // ── Fetch week totals ──
 
@@ -517,20 +509,12 @@ export const WorkPage: React.FC = () => {
     return map;
   }, [allTickets]);
 
-  const teamNamesById = useMemo(() => {
-    const map = new Map<string, string>();
-    for (const team of teams) map.set(team.id, team.name);
-    return map;
-  }, [teams]);
-
   const getWorkItemLabel = useCallback(
     (entry: DayEntry['entry']) => {
       const ticket = ticketsById.get(entry.ticketId);
-      const baseTitle = entry.displayTitle || ticket?.title || '(untitled)';
-      const teamName = ticket ? teamNamesById.get(ticket.teamId) : undefined;
-      return teamName ? `${baseTitle} - ${teamName}` : baseTitle;
+      return entry.displayTitle || ticket?.title || '(untitled)';
     },
-    [ticketsById, teamNamesById],
+    [ticketsById],
   );
 
   const selectedDayLabel = useMemo(

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -781,7 +781,57 @@ export const clockApi = {
     }),
 };
 
-// ─── Notifications ────────────────────────────────────────────────────────────
+// ─── Team Dashboard API ───────────────────────────────────────────────────────
+
+export interface TeamMemberClockStatus {
+  userId: string;
+  name: string;
+  image: string | null;
+  isClockedIn: boolean;
+  isOnBreak: boolean;
+  activeClockStart: number | null;
+  todaySeconds: number;
+}
+
+export interface TeamRunningTimer {
+  timerId: string;
+  workItemId: string;
+  userId: string;
+  userName: string;
+  userImage: string | null;
+  ticketId: string;
+  ticketTitle: string;
+  startTime: number;
+}
+
+export const teamDashboardApi = {
+  getTeamClockStatus: (teamId: string) =>
+    request<{ members: TeamMemberClockStatus[] }>(
+      `/v1/clock/team-status?teamId=${encodeURIComponent(teamId)}`,
+    ).then((r) =>
+      r.members.map((m) =>
+        m.image && !/^https?:\/\//i.test(m.image)
+          ? { ...m, image: `${TIMECORE_BASE_URL}${m.image.startsWith('/') ? '' : '/'}${m.image}` }
+          : m,
+      ),
+    ),
+
+  getTeamRunningTimers: (teamId: string) =>
+    request<{ timers: TeamRunningTimer[] }>(
+      `/v1/timers/team-running?teamId=${encodeURIComponent(teamId)}`,
+    ).then((r) =>
+      r.timers.map((t) =>
+        t.userImage && !/^https?:\/\//i.test(t.userImage)
+          ? {
+              ...t,
+              userImage: `${TIMECORE_BASE_URL}${t.userImage.startsWith('/') ? '' : '/'}${t.userImage}`,
+            }
+          : t,
+      ),
+    ),
+};
+
+
 
 export interface Notification {
   id: string;

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -723,8 +723,11 @@ export const clockApi = {
       isPaused: boolean;
     }>(`/v1/clock/status?teamId=${encodeURIComponent(teamId)}`),
 
-  /** Get the current user's active clock event (any team), or null. */
-  getActive: () => request<{ event: ClockEvent | null }>('/v1/clock/active').then((r) => r.event),
+  /** Get the current user's active clock event (any team), or null. Admin can pass userId. */
+  getActive: (userId?: string) => {
+    const params = userId ? `?userId=${encodeURIComponent(userId)}` : '';
+    return request<{ event: ClockEvent | null }>(`/v1/clock/active${params}`).then((r) => r.event);
+  },
 
   /** Get all clock events for the current user. */
   getEvents: () => request<{ events: ClockEvent[] }>('/v1/clock/events').then((r) => r.events),
@@ -1094,10 +1097,11 @@ export const timerApi = {
   /** Get the currently running timer for the authenticated user, or null. */
   getRunning: () => request<{ session: Timer | null }>('/v1/timers/running').then((r) => r.session),
 
-  /** Get all entries + sessions for today in local time. */
-  getToday: () => {
+  /** Get all entries + sessions for today in local time. Admin can pass userId. */
+  getToday: (userId?: string) => {
     const tz = clientTz();
-    return request<{ entries: DayEntry[] }>(`/v1/timers/today?tz=${encodeURIComponent(tz)}`).then(
+    const userParam = userId ? `&userId=${encodeURIComponent(userId)}` : '';
+    return request<{ entries: DayEntry[] }>(`/v1/timers/today?tz=${encodeURIComponent(tz)}${userParam}`).then(
       (r) => r.entries,
     );
   },

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -834,8 +834,6 @@ export const teamDashboardApi = {
     ),
 };
 
-
-
 export interface Notification {
   id: string;
   userId: string;
@@ -1101,9 +1099,9 @@ export const timerApi = {
   getToday: (userId?: string) => {
     const tz = clientTz();
     const userParam = userId ? `&userId=${encodeURIComponent(userId)}` : '';
-    return request<{ entries: DayEntry[] }>(`/v1/timers/today?tz=${encodeURIComponent(tz)}${userParam}`).then(
-      (r) => r.entries,
-    );
+    return request<{ entries: DayEntry[] }>(
+      `/v1/timers/today?tz=${encodeURIComponent(tz)}${userParam}`,
+    ).then((r) => r.entries);
   },
 
   /** Get all entries + sessions for a local day (YYYY-MM-DD). */

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -247,7 +247,6 @@ const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => 
                       onClick={() => {
                         closeMobile();
                         openReportIssue();
-                  
                       }}
                       className={[
                         'group flex h-9 w-full items-center rounded-lg text-sm transition-colors',

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -51,7 +51,6 @@ const isReload = (() => {
 import { useSidebar } from './AppLayout';
 import { useAppFeedback } from './AppLayout';
 import { useRouter } from './router';
-import { REPO_URL } from '../lib/constants';
 
 // ─── Nav data ─────────────────────────────────────────────────────────────────
 

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -172,8 +172,9 @@ const NavLink: React.FC<{ item: NavItem; active: boolean; expanded: boolean }> =
 const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => {
   const { isExpanded, toggle, closeMobile } = useSidebar();
   const { pathname } = useRouter();
-  const { openFeedback } = useAppFeedback();
+  // const { openFeedback } = useAppFeedback();
   const expanded = variant === 'drawer' ? true : isExpanded;
+  const { openFeedback, openReportIssue } = useAppFeedback();
 
   return (
     <div className="flex h-full flex-col">
@@ -246,11 +247,8 @@ const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => 
                       type="button"
                       onClick={() => {
                         closeMobile();
-                        window.open(
-                          `${REPO_URL}/issues/new/choose`,
-                          '_blank',
-                          'noopener,noreferrer',
-                        );
+                        openReportIssue();
+                  
                       }}
                       className={[
                         'group flex h-9 w-full items-center rounded-lg text-sm transition-colors',


### PR DESCRIPTION
This pull request introduces several new team-level features for clock and timer management, improves admin capabilities for viewing other users' data, and enhances the feedback modal to support feature requests. The most important changes are grouped below:

### Team-level endpoints for clock and timer management

* Added `GET /clock/team-status` endpoint to retrieve active clock events and today's hours for all members of a team, including their clock-in status, break status, and profile information. Access is restricted to team members and admins. (`backend/src/routes/clock.ts`, `teamsCollection`, `usersCollection`, `profilesCollection`)
* Added `GET /timers/team-running` endpoint to list all running timers for members of a team, including ticket and user details. Access is restricted to team members and admins. (`backend/src/routes/timers.ts`, `timerService.getTeamRunningTimers`) 

### Admin access improvements

* Extended endpoints for clock and timer events to allow admins to query data for other users by specifying a `userId` parameter, with proper permission checks to ensure only admins of a shared team can access another user's data. (`backend/src/routes/clock.ts`, `backend/src/routes/timers.ts`) 

### Timer and clock integration

* When ending a break, automatically restarts the timer that was stopped when the break began, ensuring seamless time tracking across breaks. 

### Feedback modal enhancements

* Updated the feedback modal to support both bug reports and feature requests, including a UI for selecting the issue type and routing submissions to the correct inbox. 

### Minor improvements

* Prevented admin notification spam by not notifying the acting admin when they update timesheets. (`timerService.notifyTeamAdminsOfTimesheetUpdate`)
* Refactored timer entry creation to use `getOrCreateEntry` for consistency. (`backend/src/routes/timers.ts`)This pull request introduces several new features and improvements to team-based time tracking and admin capabilities, particularly around clock events and timers. The main enhancements include new endpoints for fetching team-wide clock and timer statuses, admin access to view other users' daily work data, and improved synchronization between clock breaks and timers. The UI is also updated to allow admins to view the current status card for team members.

**API and Backend Enhancements:**

*Team-based endpoints and admin features:*
- Added `/clock/team-status` and `/timers/team-running` endpoints to fetch the current clock-in status and running timers for all members of a team, including today’s work duration and user info. These endpoints enforce team membership/admin checks. 
- Allowed admins to view another user's active clock event and today's timer entries by providing a `userId` query parameter. Admin access is verified by checking shared teams. 

*Timer and clock integration:*
- When ending a clock break, if a timer was stopped at the break start, it is now automatically restarted for the same work item, improving timer/clock synchronization. 

*Other backend improvements:*
- Added methods to find a timer closed at a specific time and to restart a timer for a work item.
- Modified timer entry creation to use `getOrCreateEntry` for consistency and clarified admin notification logic. 

**Frontend/UI Updates:**

*Profile and status card:*
- Updated the `TodayStatusCard` component and profile page so that admins can view the current clock/timer status for team members, not just themselves. The card now accepts a `userId` prop and fetches data accordingly, polling for updates when viewing another user. 

These changes collectively improve team visibility for admins, support better synchronization between clock and timer systems, and enhance the user interface for team management.