### PR TITLE
Fix org-scoped team and ticket creation

### DIFF
--- a/backend/src/routes/tickets.ts
+++ b/backend/src/routes/tickets.ts
@@ -228,7 +228,7 @@ export async function ticketRoutes(app: FastifyInstance) {
           required: ["teamId", "title"],
           additionalProperties: false,
           properties: {
-            teamId: { type: "string" },
+            teamId: { type: "string", minLength: 1, pattern: "^[0-9a-f]{24}$" },
             title: { type: "string", minLength: 1, maxLength: 500 },
             github: { type: "string", maxLength: 1000, default: "" },
           },
@@ -236,6 +236,7 @@ export async function ticketRoutes(app: FastifyInstance) {
         response: {
           201: { type: "object", properties: { ticket: ticketShape } },
           ...unauth,
+          400: err("teamId is required"),
           403: err("Not a team member"),
         },
       },
@@ -252,6 +253,9 @@ export async function ticketRoutes(app: FastifyInstance) {
         github: body.github ?? "",
         createdBy: req.user!.id,
       });
+      if (result === "bad-request") {
+        return reply.status(400).send({ error: "teamId is required" });
+      }
       if (result === "forbidden") return reply.status(403).send({ error: "Not a team member" });
       const ticket = await ticketService.findById(result.id);
       return reply.status(201).send({ ticket: toPublicTicket(ticket!) });

--- a/backend/src/services/ticket.service.ts
+++ b/backend/src/services/ticket.service.ts
@@ -21,6 +21,7 @@ import { pushService } from "./push.service.js";
 
 type OwnerError = "not-found" | "forbidden";
 type AssignError = "not-found" | "forbidden" | "bad-assignee";
+type CreateError = "forbidden" | "bad-request";
 
 function isValidId(id: string): boolean {
   return /^[0-9a-f]{24}$/i.test(id);
@@ -259,7 +260,11 @@ export class TicketService {
     title: string;
     github: string;
     createdBy: string;
-  }): Promise<{ id: string } | "forbidden"> {
+  }): Promise<{ id: string } | CreateError> {
+    if (!data.teamId || !isValidId(data.teamId)) {
+      return "bad-request";
+    }
+
     const context = await this.buildTeamAbility(data.createdBy, data.teamId);
     if (!context) return "forbidden";
     if (!context.ability.can("create", subject("Ticket", { teamId: data.teamId }))) {

--- a/backend/tests/teams.test.ts
+++ b/backend/tests/teams.test.ts
@@ -13,6 +13,7 @@ import { ObjectId } from "mongodb";
 import { buildApp } from "../src/server.js";
 import { connectDB, client } from "../src/lib/db.js";
 import { auth } from "../src/lib/auth.js";
+import { orgMembersCollection, organizationsCollection } from "../src/models/index.js";
 
 // ─── Fixtures ─────────────────────────────────────────────────────────────────
 
@@ -28,6 +29,7 @@ let ownerId: string;
 let memberId: string;
 let outsiderId: string;
 let teamId: string;
+let secondaryOrgId: string;
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -98,6 +100,16 @@ beforeAll(async () => {
   await db.collection("teams").insertOne(teamDoc);
   teamId = teamDoc._id.toHexString();
 
+  const secondaryOrgDoc = {
+    _id: new ObjectId(),
+    name: "Secondary Team Org",
+    slug: "secondary-team-org",
+    allowAutoJoin: true,
+    createdAt: new Date(),
+  };
+  await organizationsCollection().insertOne(secondaryOrgDoc);
+  secondaryOrgId = secondaryOrgDoc._id.toHexString();
+
   ownerCookie = await getSessionCookie(OWNER.email, OWNER.password);
   memberCookie = await getSessionCookie(MEMBER.email, MEMBER.password);
   outsiderCookie = await getSessionCookie(OUTSIDER.email, OUTSIDER.password);
@@ -106,6 +118,10 @@ beforeAll(async () => {
 afterAll(async () => {
   const db = client.db();
   await db.collection("teams").deleteMany({ code: { $regex: /^TEAMCODE|^PERSONAL/ } });
+  if (secondaryOrgId) {
+    await orgMembersCollection().deleteMany({ orgId: secondaryOrgId });
+    await organizationsCollection().deleteOne({ _id: new ObjectId(secondaryOrgId) });
+  }
   await Promise.all([purgeUser(OWNER.email), purgeUser(MEMBER.email), purgeUser(OUTSIDER.email)]);
   await app.close();
 });
@@ -183,6 +199,21 @@ describe("POST /v1/teams", () => {
     expect(team.admins).toContain(ownerId);
     expect(team.isPersonal).toBe(false);
     expect(typeof team.code).toBe("string");
+    // cleanup
+    await client
+      .db()
+      .collection("teams")
+      .deleteOne({ _id: new ObjectId(team.id) });
+  });
+
+  it("creates a team in the requested organization — 201", async () => {
+    const res = await inject("POST", "/v1/teams", ownerCookie, {
+      name: "Org-Specific Team",
+      orgId: secondaryOrgId,
+    });
+    expect(res.statusCode).toBe(201);
+    const { team } = res.json();
+    expect(team.orgId).toBe(secondaryOrgId);
     // cleanup
     await client
       .db()

--- a/backend/tests/tickets.test.ts
+++ b/backend/tests/tickets.test.ts
@@ -207,6 +207,16 @@ describe("auth gate", () => {
 // ─── Create ───────────────────────────────────────────────────────────────────
 
 describe("POST /v1/tickets", () => {
+  it("rejects missing teamId — 400", async () => {
+    const res = await app.inject({
+      method: "POST",
+      url: "/v1/tickets",
+      headers: { cookie: ownerCookie },
+      payload: { title: "Missing team" },
+    });
+    expect(res.statusCode).toBe(400);
+  });
+
   it("creates a ticket as a team member — 201", async () => {
     const res = await app.inject({
       method: "POST",

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -62,7 +62,15 @@ export const TeamsPage: React.FC = () => {
   const { user } = useSession();
   const userId = user?.id ?? null;
   const { navigate } = useRouter();
-  const { teams, teamsReady, selectedTeamId, setSelectedTeamId, isAdmin, refetchTeams } = useTeam();
+  const {
+    teams,
+    teamsReady,
+    selectedOrgId,
+    selectedTeamId,
+    setSelectedTeamId,
+    isAdmin,
+    refetchTeams,
+  } = useTeam();
 
   // Fetch members for selected team
   const [members, setMembers] = useState<TeamMember[]>([]);
@@ -139,11 +147,16 @@ export const TeamsPage: React.FC = () => {
 
   const handleCreate = useCallback(async () => {
     if (!formValue.trim()) return;
+    if (!selectedOrgId) {
+      setFormError('Select an organization before creating a team.');
+      return;
+    }
     setCreateLoading(true);
     try {
       const team = await teamApi.createTeam({
         name: formValue.trim(),
         description: createDescription.trim() || undefined,
+        orgId: selectedOrgId,
       });
       setSelectedTeamId(team.id);
       setModal({ type: 'created', code: team.code });
@@ -155,7 +168,7 @@ export const TeamsPage: React.FC = () => {
     } finally {
       setCreateLoading(false);
     }
-  }, [formValue, createDescription, setSelectedTeamId, refetchTeams]);
+  }, [formValue, createDescription, selectedOrgId, setSelectedTeamId, refetchTeams]);
 
   const handleJoin = useCallback(async () => {
     if (!formValue.trim()) return;
@@ -544,6 +557,7 @@ export const TeamsPage: React.FC = () => {
             onClick={handleCreate}
             isLoading={createLoading}
             loadingText="Creating…"
+            disabled={!selectedOrgId}
           >
             Create
           </Button>

--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -468,8 +468,9 @@ const TicketListSkeleton: React.FC = () => (
 export const TicketsPage: React.FC = () => {
   const { user } = useSession();
   const userId = user?.id ?? null;
-  const { teams, selectedTeamId, teamsReady } = useTeam();
+  const { teams, selectedTeam, selectedTeamId, teamsReady } = useTeam();
   const { isClockedIn, clockIn } = useClockToggle();
+  const { navigate } = useRouter();
 
   const [tickets, setTickets] = useState<Ticket[]>([]);
   const [ticketsLoading, setTicketsLoading] = useState(true);
@@ -654,6 +655,7 @@ export const TicketsPage: React.FC = () => {
 
   // Create state
   const [showCreate, setShowCreate] = useState(false);
+  const [showNoTeamDialog, setShowNoTeamDialog] = useState(false);
   const [createTitle, setCreateTitle] = useState('');
   const [createGithub, setCreateGithub] = useState('');
   const [createTitleFetching, setCreateTitleFetching] = useState(false);
@@ -917,11 +919,16 @@ export const TicketsPage: React.FC = () => {
   }, [pendingStartTicketId, selectedTeamId, clockIn, startTimerForTicket]);
 
   const handleCreate = useCallback(async () => {
-    if (!createTitle.trim() || !selectedTeamId) return;
+    if (!createTitle.trim()) return;
+    if (!selectedTeam) {
+      setShowCreate(false);
+      setShowNoTeamDialog(true);
+      return;
+    }
     setCreateLoading(true);
     try {
       await ticketApi.createTicket({
-        teamId: selectedTeamId,
+        teamId: selectedTeam.id,
         title: createTitle.trim(),
         github: createGithub.trim() || undefined,
       });
@@ -932,7 +939,7 @@ export const TicketsPage: React.FC = () => {
     } finally {
       setCreateLoading(false);
     }
-  }, [createTitle, createGithub, selectedTeamId, refetch]);
+  }, [createTitle, createGithub, refetch, selectedTeam]);
 
   const openEditModal = (ticket: Ticket) => {
     setEditTicket(ticket);
@@ -1008,7 +1015,13 @@ export const TicketsPage: React.FC = () => {
               variant="primary"
               size="sm"
               leftIcon={<FontAwesomeIcon icon={faPlus} />}
-              onClick={() => setShowCreate(true)}
+              onClick={() => {
+                if (!selectedTeam) {
+                  setShowNoTeamDialog(true);
+                  return;
+                }
+                setShowCreate(true);
+              }}
               className="shrink-0 rounded-lg"
             >
               New Ticket
@@ -1121,7 +1134,7 @@ export const TicketsPage: React.FC = () => {
                   type="submit"
                   isLoading={createLoading}
                   loadingText="Creating…"
-                  disabled={!createTitle.trim()}
+                  disabled={!createTitle.trim() || !selectedTeam}
                 >
                   Create Ticket
                 </Button>
@@ -1695,6 +1708,36 @@ export const TicketsPage: React.FC = () => {
             </Button>
             <Button variant="primary" onClick={handleClockInAndStart}>
               Clock In Now
+            </Button>
+          </ModalFooter>
+        </Modal>
+
+        <Modal open={showNoTeamDialog} onOpenChange={setShowNoTeamDialog} size="sm">
+          <ModalHeader>
+            <ModalTitle>No team available</ModalTitle>
+            <ModalClose />
+          </ModalHeader>
+          <ModalBody className="space-y-3">
+            <Text size="sm" className="text-neutral-600 dark:text-neutral-300">
+              This organization does not have a team yet. A team must exist before tickets can be
+              created.
+            </Text>
+            <Text size="sm" className="text-neutral-600 dark:text-neutral-300">
+              Create or join a team in this organization, then come back to add tickets.
+            </Text>
+          </ModalBody>
+          <ModalFooter>
+            <Button variant="outline" onClick={() => setShowNoTeamDialog(false)}>
+              Close
+            </Button>
+            <Button
+              variant="primary"
+              onClick={() => {
+                setShowNoTeamDialog(false);
+                navigate('/app/teams');
+              }}
+            >
+              Go to Teams
             </Button>
           </ModalFooter>
         </Modal>

--- a/src/ui/CommandPalette.tsx
+++ b/src/ui/CommandPalette.tsx
@@ -268,14 +268,14 @@ export const CommandPalette: React.FC = () => {
   );
 
   const handleCreateTicket = useCallback(async () => {
-    if (preview.status !== 'ready' || !selectedTeamId) return;
+    if (preview.status !== 'ready' || !selectedTeam) return;
 
     const { url, issue } = preview;
     setPreview({ status: 'creating', url, issue });
 
     try {
       await createTicketFromGithub({
-        teamId: selectedTeamId,
+        teamId: selectedTeam.id,
         url,
         title: issue.title,
         description: issue.body,
@@ -286,17 +286,17 @@ export const CommandPalette: React.FC = () => {
     } catch {
       setPreview({ status: 'error', url, message: 'Failed to create ticket' });
     }
-  }, [preview, selectedTeamId, navigate]);
+  }, [preview, selectedTeam, navigate]);
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
-      if (e.key === 'Enter' && preview.status === 'ready' && selectedTeamId) {
+      if (e.key === 'Enter' && preview.status === 'ready' && selectedTeam) {
         e.preventDefault();
         void handleCreateTicket();
         return;
       }
     },
-    [preview.status, selectedTeamId, handleCreateTicket],
+    [preview.status, selectedTeam, handleCreateTicket],
   );
 
   const openMessageToMember = useCallback(
@@ -352,7 +352,7 @@ export const CommandPalette: React.FC = () => {
   }, [open, highlightedMemberId, openMessageToMember]);
 
   const isGithubMode = preview.status !== 'idle';
-  const canCreate = preview.status === 'ready' && selectedTeamId;
+  const canCreate = preview.status === 'ready' && !!selectedTeam;
 
   return (
     <Command.Dialog
@@ -416,7 +416,7 @@ export const CommandPalette: React.FC = () => {
                       {stripMarkdown(preview.issue.body)}
                     </p>
                   )}
-                  {!selectedTeamId && teamsReady && (
+                  {!selectedTeam && teamsReady && (
                     <p className="mt-2 text-xs text-amber-600 dark:text-amber-400">
                       Select a team first to create a ticket
                     </p>


### PR DESCRIPTION
Prevent confusion when trying to create tickets under an org that has no team yet.  This is because tickets have a direct teamId association.  When no team present on the org and a ticket create is attempted, this dialog will show.

<img width="608" height="397" alt="Screenshot 2026-06-11 at 1 11 08 PM" src="https://github.com/user-attachments/assets/8e9998cd-df3c-4809-ad13-b57b78e45f85" />

Guiding the user to create a team first.

Fixes #286 