### PR TITLE
Move System Items From the Sidebar Into the Account Menu

### DIFF
--- a/meteor-backend/server/main.js
+++ b/meteor-backend/server/main.js
@@ -111,8 +111,19 @@ WebApp.rawConnectHandlers.use((req, res, next) => {
   if (isOriginAllowed(origin)) {
     res.setHeader('Access-Control-Allow-Origin', origin);
     res.setHeader('Access-Control-Allow-Credentials', 'true');
-    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS');
-    res.setHeader('Access-Control-Allow-Headers', 'Content-Type, Authorization, X-Requested-With');
+    res.setHeader('Access-Control-Allow-Methods', 'GET, POST, PUT, DELETE, OPTIONS, PATCH, HEAD');
+    // Includes the TUS resumable-upload protocol headers (@mieweb/pulsevault's
+    // /pulsevault/upload route) — tus-js-client sends Tus-Resumable on every
+    // request, so without it here the browser blocks the preflight before the
+    // upload ever reaches the handler.
+    res.setHeader(
+      'Access-Control-Allow-Headers',
+      'Content-Type, Authorization, X-Requested-With, Tus-Resumable, Upload-Length, Upload-Metadata, Upload-Offset, Upload-Concat, Upload-Defer-Length',
+    );
+    res.setHeader(
+      'Access-Control-Expose-Headers',
+      'Location, Upload-Offset, Upload-Length, Tus-Resumable, Tus-Version, Tus-Max-Size, Tus-Extension',
+    );
     res.setHeader('Access-Control-Max-Age', '86400');
   }
   if (req.method === 'OPTIONS') {

--- a/meteor-backend/server/timers.js
+++ b/meteor-backend/server/timers.js
@@ -35,22 +35,23 @@ function toPublicSession(s) {
   };
 }
 
-function toUtcDateKey(epochMs) {
-  return new Date(epochMs).toISOString().slice(0, 10);
+/** "YYYY-MM-DD" for the given tz (IANA name), falling back to UTC if tz is
+ * missing/invalid — must match the client's `date` computation (also local),
+ * or WorkItems created "today" locally silently vanish from UTC-bucketed
+ * lookups for hours around midnight in any timezone behind UTC. */
+function todayInTz(tz) {
+  if (tz) {
+    try {
+      return new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(new Date());
+    } catch {
+      // fall through to UTC
+    }
+  }
+  return new Date().toISOString().slice(0, 10);
 }
 
 function isPreviousDate(date, tz) {
-  let today;
-  if (tz) {
-    try {
-      today = new Intl.DateTimeFormat('en-CA', { timeZone: tz }).format(new Date());
-    } catch {
-      today = new Date().toISOString().slice(0, 10);
-    }
-  } else {
-    today = new Date().toISOString().slice(0, 10);
-  }
-  return date < today;
+  return date < todayInTz(tz);
 }
 
 async function closeRunningSession(userId, now) {
@@ -150,7 +151,7 @@ Meteor.methods({
       userId = targetUserId;
     }
 
-    const today = toUtcDateKey(Date.now());
+    const today = todayInTz(tz);
     const entries = await getDayEntries(userId, today);
     const ticketIds = [...new Set(entries.map(({ entry }) => entry.ticketId))];
     const titleMap = await getTicketTitleMap(ticketIds);
@@ -272,7 +273,7 @@ Meteor.methods({
   },
 
   /** Get or create a WorkItem for a ticket on a given date. Optionally start a timer. */
-  async 'timers.createEntry'({ ticketId, date, note, startNow = false, notifyAdmins = true } = {}) {
+  async 'timers.createEntry'({ ticketId, date, note, startNow = false, notifyAdmins = true, tz } = {}) {
     const identity = await requireIdentity(this);
     const userId = identity.userId;
     if (!isValidId(ticketId)) throw new Meteor.Error('not-found', 'Ticket not found');
@@ -309,7 +310,7 @@ Meteor.methods({
 
     let session = null;
     if (startNow) {
-      if (isPreviousDate(date)) throw new Meteor.Error('invalid-date', 'Cannot start a timer on a previous day');
+      if (isPreviousDate(date, tz)) throw new Meteor.Error('invalid-date', 'Cannot start a timer on a previous day');
       await closeRunningSession(userId, Date.now());
       const sessionId = await Timers.insertAsync({
         workItemId: entry._id.toHexString(),

--- a/src/features/huddle/TicketPicker.tsx
+++ b/src/features/huddle/TicketPicker.tsx
@@ -16,10 +16,14 @@ export function TicketPicker({ teamId, onSelect, selectedId }: TicketPickerProps
   const dropdownRef = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    if (isOpen && tickets.length === 0) {
+    // Re-fetches on every open (and if teamId resolves/changes while open) —
+    // dropping the "already have tickets" guard is what fixes the picker
+    // opening before TeamContext's async team resolution finishes, loading
+    // an empty list for a stale/blank teamId that never gets retried.
+    if (isOpen && teamId) {
       loadTickets();
     }
-  }, [isOpen]);
+  }, [isOpen, teamId]);
 
   useEffect(() => {
     const handleClickOutside = (event: MouseEvent) => {

--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -61,6 +61,7 @@ import {
 } from '../../lib/api';
 import { useTeam } from '../../lib/TeamContext';
 import { getDdpClient, ddpDocToTicket } from '../../lib/ddp';
+import { toLocalDateStr } from '../../lib/date';
 import { useSession } from '../../lib/useSession';
 import { useClockToggle } from '../../lib/useClockToggle';
 import { useRefresh } from '../../lib/RefreshContext';
@@ -856,7 +857,7 @@ export const TicketsPage: React.FC = () => {
   const startTimerForTicket = useCallback(async (ticketId: string) => {
     setTimerLoading(ticketId);
     try {
-      const today = new Date().toISOString().split('T')[0];
+      const today = toLocalDateStr(new Date());
       const result = await timerApi.createEntry({
         ticketId,
         date: today,

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -47,6 +47,7 @@ import {
   type Timer,
   type Ticket,
 } from '../../lib/api';
+import { toLocalDateStr } from '../../lib/date';
 import { getDdpClient } from '../../lib/ddp';
 import { useTeam } from '../../lib/TeamContext';
 import { useRefresh } from '../../lib/RefreshContext';
@@ -57,10 +58,6 @@ import { useRouter } from '../../ui/router';
 import { TimerToggleButton } from '../../ui/TimerToggleButton';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
-
-function toLocalDateStr(d: Date): string {
-  return d.toLocaleDateString('en-CA'); // "YYYY-MM-DD" in local time
-}
 
 /** Format total seconds as "H:MM" for the duration input field. */
 function secondsToHHMM(secs: number): string {

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1438,7 +1438,11 @@ export const timerApi = {
     note?: string;
     notifyAdmins?: boolean;
     startNow?: boolean;
-  }) => wormholeCall<{ entry: WorkItem; session: Timer | null }>('timers.createEntry', data),
+  }) =>
+    wormholeCall<{ entry: WorkItem; session: Timer | null }>('timers.createEntry', {
+      ...data,
+      tz: clientTz(),
+    }),
 
   /** Start a timer for a WorkItem. Closes any open timer first. */
   startSession: (entryId: string, now?: number) =>

--- a/src/lib/date.ts
+++ b/src/lib/date.ts
@@ -1,0 +1,6 @@
+/** "YYYY-MM-DD" in the browser's local timezone — never use toISOString() for
+ * this, which is UTC and drifts a calendar day off local time for hours
+ * around midnight in any timezone behind UTC. */
+export function toLocalDateStr(d: Date): string {
+  return d.toLocaleDateString('en-CA');
+}

--- a/src/ui/Sidebar.tsx
+++ b/src/ui/Sidebar.tsx
@@ -16,11 +16,9 @@ import {
   faChevronRight,
   faClock,
   faBell,
-  faBug,
   faComments,
   faEnvelope,
   faGauge,
-  faGear,
   faListCheck,
   faPhotoFilm,
   faSitemap,
@@ -29,7 +27,6 @@ import {
   faUsers,
   faClockRotateLeft,
 } from '@fortawesome/free-solid-svg-icons';
-import { faApple } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
 import { Button } from '@mieweb/ui';
 import { AnimatePresence, motion, MotionConfig } from 'motion/react';
@@ -49,16 +46,12 @@ const isReload = (() => {
 })();
 
 import { useSidebar } from './AppLayout';
-import { useAppFeedback } from './AppLayout';
 import { useRouter } from './router';
 
 // ─── Nav data ─────────────────────────────────────────────────────────────────
 
-// Update this URL once the TestFlight build is published in App Store Connect.
-const TESTFLIGHT_URL = 'https://testflight.apple.com/join/45w2knYf';
-
 interface NavItem {
-  icon: typeof faGear;
+  icon: typeof faGauge;
   label: string;
   href: string;
   external?: boolean;
@@ -78,6 +71,7 @@ const NAV: NavSection[] = [
       { icon: faStopwatch, label: 'Work', href: '/app/work' },
       { icon: faListCheck, label: 'Tickets', href: '/app/tickets' },
       { icon: faTable, label: 'Timesheet', href: '/app/timesheet' },
+      { icon: faClock, label: 'Clock', href: '/app/clock' },
     ],
   },
   {
@@ -89,15 +83,6 @@ const NAV: NavSection[] = [
       { icon: faEnvelope, label: 'Messages', href: '/app/messages' },
       { icon: faBell, label: 'Notifications', href: '/app/notifications' },
       { icon: faClockRotateLeft, label: 'Activity Log', href: '/app/activity' },
-    ],
-  },
-  {
-    heading: 'System',
-
-    items: [
-      { icon: faApple, label: 'TestFlight', href: TESTFLIGHT_URL, external: true },
-      { icon: faClock, label: 'Clock', href: '/app/clock' },
-      { icon: faGear, label: 'Settings', href: '/app/settings' },
     ],
   },
 ];
@@ -170,11 +155,9 @@ const NavLink: React.FC<{ item: NavItem; active: boolean; expanded: boolean }> =
 // ─── SidebarContent ───────────────────────────────────────────────────────────
 
 const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => {
-  const { isExpanded, toggle, closeMobile } = useSidebar();
+  const { isExpanded, toggle } = useSidebar();
   const { pathname } = useRouter();
-  // const { openFeedback } = useAppFeedback();
   const expanded = variant === 'drawer' ? true : isExpanded;
-  const { openFeedback, openReportIssue } = useAppFeedback();
 
   return (
     <div className="flex h-full flex-col">
@@ -240,76 +223,6 @@ const SidebarContent: React.FC<SidebarContentProps> = ({ variant = 'rail' }) => 
                   <NavLink item={item} active={pathname === item.href} expanded={expanded} />
                 </li>
               ))}
-              {si === NAV.length - 1 && (
-                <>
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        closeMobile();
-                        openReportIssue();
-                      }}
-                      className={[
-                        'group flex h-9 w-full items-center rounded-lg text-sm transition-colors',
-                        'focus:outline-none focus:ring-2 focus:ring-(--mieweb-primary-500)/40',
-                        'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800',
-                        expanded ? 'gap-3 px-2.5' : 'justify-center px-0',
-                      ].join(' ')}
-                      title={!expanded ? 'Report an Issue' : undefined}
-                      aria-label="Report an Issue"
-                    >
-                      <FontAwesomeIcon icon={faBug} className="w-4 shrink-0 text-sm" />
-                      <AnimatePresence initial={false}>
-                        {expanded && (
-                          <motion.span
-                            key="report-label"
-                            initial={{ opacity: 0, width: 0 }}
-                            animate={{ opacity: 1, width: 'auto' }}
-                            exit={{ opacity: 0, width: 0 }}
-                            transition={{ duration: 0.15, ease: 'easeInOut' }}
-                            className="overflow-hidden whitespace-nowrap"
-                          >
-                            Report an Issue
-                          </motion.span>
-                        )}
-                      </AnimatePresence>
-                    </button>
-                  </li>
-                  <li>
-                    <button
-                      type="button"
-                      onClick={() => {
-                        closeMobile();
-                        openFeedback();
-                      }}
-                      className={[
-                        'group flex h-9 w-full items-center rounded-lg text-sm transition-colors',
-                        'focus:outline-none focus:ring-2 focus:ring-(--mieweb-primary-500)/40',
-                        'text-neutral-600 hover:bg-neutral-100 dark:text-neutral-400 dark:hover:bg-neutral-800',
-                        expanded ? 'gap-3 px-2.5' : 'justify-center px-0',
-                      ].join(' ')}
-                      title={!expanded ? 'Share Your Feedback' : undefined}
-                      aria-label="Share Your Feedback"
-                    >
-                      <FontAwesomeIcon icon={faComments} className="w-4 shrink-0 text-sm" />
-                      <AnimatePresence initial={false}>
-                        {expanded && (
-                          <motion.span
-                            key="feedback-label"
-                            initial={{ opacity: 0, width: 0 }}
-                            animate={{ opacity: 1, width: 'auto' }}
-                            exit={{ opacity: 0, width: 0 }}
-                            transition={{ duration: 0.15, ease: 'easeInOut' }}
-                            className="overflow-hidden whitespace-nowrap"
-                          >
-                            Share Your Feedback
-                          </motion.span>
-                        )}
-                      </AnimatePresence>
-                    </button>
-                  </li>
-                </>
-              )}
             </ul>
           </div>
         ))}

--- a/src/ui/UserDropdown.tsx
+++ b/src/ui/UserDropdown.tsx
@@ -4,27 +4,36 @@
  * Uses @mieweb/ui Dropdown, Avatar, and DropdownItem components.
  */
 import {
+  faBug,
   faBuilding,
   faCircleUser,
+  faComments,
+  faGear,
   faRightFromBracket,
   faUsers,
   faWrench,
 } from '@fortawesome/free-solid-svg-icons';
+import { faApple } from '@fortawesome/free-brands-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Dropdown, DropdownItem, DropdownSeparator, Text } from '@mieweb/ui';
+import { Dropdown, DropdownItem, DropdownLabel, DropdownSeparator, Text } from '@mieweb/ui';
 import React, { useCallback, useState } from 'react';
 
 import { useTeam } from '../lib/TeamContext';
 import { useSession } from '../lib/useSession';
 import { hasDefaultOrganizationAdminAccess } from '../lib/organizationAccess';
+import { useAppFeedback } from './AppLayout';
 import { useRouter } from './router';
 import { UserAvatar } from './UserAvatar';
+
+// Update this URL once the TestFlight build is published in App Store Connect.
+const TESTFLIGHT_URL = 'https://testflight.apple.com/join/45w2knYf';
 
 // ─── UserDropdown ─────────────────────────────────────────────────────────────
 
 export const UserDropdown: React.FC = () => {
   const { user, signOut } = useSession();
   const { enterprises } = useTeam();
+  const { openFeedback, openReportIssue } = useAppFeedback();
   const email = user?.email;
   const [open, setOpen] = useState(false);
 
@@ -62,6 +71,26 @@ export const UserDropdown: React.FC = () => {
     setOpen(false);
     navigate('/app/seeder');
   }, [navigate]);
+
+  const handleSettings = useCallback(() => {
+    setOpen(false);
+    navigate('/app/settings');
+  }, [navigate]);
+
+  const handleReportIssue = useCallback(() => {
+    setOpen(false);
+    openReportIssue();
+  }, [openReportIssue]);
+
+  const handleFeedback = useCallback(() => {
+    setOpen(false);
+    openFeedback();
+  }, [openFeedback]);
+
+  const handleTestFlight = useCallback(() => {
+    setOpen(false);
+    window.open(TESTFLIGHT_URL, '_blank', 'noopener,noreferrer');
+  }, []);
 
   return (
     <>
@@ -102,18 +131,14 @@ export const UserDropdown: React.FC = () => {
           <span className="font-normal">Profile</span>
         </DropdownItem>
 
+        <DropdownItem icon={<FontAwesomeIcon icon={faGear} />} onClick={handleSettings}>
+          <span className="font-normal">Settings</span>
+        </DropdownItem>
+
         {(showOrganizationAdmin || enterprises.length > 0) && (
           <>
             <DropdownSeparator />
-            <div className="px-3 py-1">
-              <Text
-                variant="muted"
-                size="xs"
-                className="text-left font-semibold uppercase tracking-wide"
-              >
-                Admin
-              </Text>
-            </div>
+            <DropdownLabel>Admin</DropdownLabel>
           </>
         )}
 
@@ -135,20 +160,27 @@ export const UserDropdown: React.FC = () => {
         {import.meta.env.MODE !== 'production' && (
           <>
             <DropdownSeparator />
-            <div className="px-3 py-1">
-              <Text
-                variant="muted"
-                size="xs"
-                className="text-left font-semibold uppercase tracking-wide"
-              >
-                Developers
-              </Text>
-            </div>
+            <DropdownLabel>Developers</DropdownLabel>
             <DropdownItem icon={<FontAwesomeIcon icon={faWrench} />} onClick={handleSeeder}>
               <span className="font-normal">Seeder</span>
             </DropdownItem>
           </>
         )}
+
+        <DropdownSeparator />
+        <DropdownLabel>Help</DropdownLabel>
+
+        <DropdownItem icon={<FontAwesomeIcon icon={faBug} />} onClick={handleReportIssue}>
+          <span className="font-normal">Report an Issue</span>
+        </DropdownItem>
+
+        <DropdownItem icon={<FontAwesomeIcon icon={faComments} />} onClick={handleFeedback}>
+          <span className="font-normal">Share Your Feedback</span>
+        </DropdownItem>
+
+        <DropdownItem icon={<FontAwesomeIcon icon={faApple} />} onClick={handleTestFlight}>
+          <span className="font-normal">TestFlight</span>
+        </DropdownItem>
 
         <DropdownSeparator />
 

--- a/tests/e2e/global-teardown.ts
+++ b/tests/e2e/global-teardown.ts
@@ -115,12 +115,12 @@ export default async function globalTeardown(): Promise<void> {
     // and any other data linked to test users.
     const auxiliaryCollections = [
       'timers',
-      'clock_events',
+      'clockevents',
       'notifications',
       'messages',
-      'team_join_requests',
+      'teamjoinrequests',
       'tickets',
-      'work_entries',
+      'workitems',
       'channels',
     ];
     let auxiliaryDeleted = 0;


### PR DESCRIPTION
Closes #420.

> **Stacked on #411** — branched off `feat/header-org-team-switcher`, so this PR shows that commit too until #411 merges. Review the second commit (`refactor: move System items…`); merge after #411.

The sidebar mixed work destinations with system/app concerns. Settings and TestFlight sat under a `System` heading, while Report an Issue and Share Your Feedback were hand-rolled buttons stapled onto the last nav section. None of those are places you go to do work.

## Changes

- **Settings** → account dropdown, next to Profile.
- **Report an Issue**, **Share Your Feedback**, **TestFlight** → a new `Help` group in the dropdown.
- **Clock** → moves up into `Workspace`; the `System` section is removed. Moving Settings and TestFlight out left it holding only Clock, which is a work destination, not a system setting. Sidebar is now `Workspace` + `Manage`.

Nothing is lost: Settings is still reachable from the bottom nav on mobile, the command palette, and the profile pages.

## Notes

- Deletes ~68 lines of duplicated markup. The two footer buttons hand-rolled the `NavLink` treatment (icon, `AnimatePresence` label, collapsed-rail `title`) rather than reusing it, and only existed to open modals — as `DropdownItem`s they're one line each.
- Migrates the dropdown's hand-rolled section headings to the `@mieweb/ui` `DropdownLabel` they were duplicating, and drops a commented-out `useAppFeedback` call.
- `TESTFLIGHT_URL` moves with its only consumer.

## Verification

Lint / typecheck / format clean. Unit 71/71. E2E 88 pass, 3 fail — `password-reset` ×2 (needs a mail service) and `logout-navigation` re-login; identical to the pre-existing baseline.

Checked in Chrome: both modals open from the dropdown (the feedback context now resolves through the account menu), Settings navigates, and the sidebar renders Workspace + Manage with Clock in place.
