### PR TITLE
Move the Page Title From the Nav Bar Into the Page Body

### DIFF
--- a/src/pages/Huddle.tsx
+++ b/src/pages/Huddle.tsx
@@ -1,7 +1,12 @@
+import { faBell, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
+import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
+import { Button } from '@mieweb/ui';
 import { useState, useEffect } from 'react';
 import { HuddleComposer } from '../features/huddle/HuddleComposer';
 import { PostCard } from '../features/huddle/PostCard';
 import type { ComposerContent } from '../features/huddle/types';
+import { PageTitle } from '../ui/pageTitle';
+import { useRouter } from '../ui/router';
 import { useSession } from '@lib/useSession';
 import { useTeam } from '@lib/TeamContext';
 import { teamApi, type HuddlePost, type Team } from '@lib/api';
@@ -29,6 +34,7 @@ function getUserColor(userId: string): 'indigo' | 'teal' | 'coral' | 'amber' | '
 }
 
 export default function Huddle() {
+  const { navigate } = useRouter();
   const [posts, setPosts] = useState<HuddlePost[]>([]);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -169,50 +175,28 @@ export default function Huddle() {
     <div className="flex flex-col h-full bg-gray-50 dark:bg-neutral-900 min-h-screen">
       {/* Sticky header section with both title and composer */}
       <div className="sticky top-0 z-10 bg-white dark:bg-neutral-800 shrink-0">
-        {/* Header */}
-        <div className="flex items-center justify-between px-5 py-3 border-b border-gray-100 dark:border-neutral-700">
-          <h1 className="text-lg font-semibold text-gray-900 dark:text-neutral-100 tracking-tight">
-            Huddle
-          </h1>
-          <div className="flex gap-2">
-            <button
+        {/* Header — the page name comes from the shared PageTitle */}
+        <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-gray-100 dark:border-neutral-700">
+          <PageTitle />
+          <div className="flex shrink-0 gap-2">
+            <Button
+              variant="ghost"
+              size="icon"
               onClick={() => setShowSearch(!showSearch)}
-              className="w-8 h-8 rounded-full bg-gray-100 dark:bg-neutral-700 flex items-center justify-center hover:bg-gray-200 dark:hover:bg-neutral-600 transition-colors"
+              aria-label="Search posts"
               title="Search posts"
             >
-              <svg
-                className="w-4 h-4 text-gray-500 dark:text-neutral-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-            </button>
-            <a
-              href="/app/notifications"
-              className="w-8 h-8 rounded-full bg-gray-100 dark:bg-neutral-700 flex items-center justify-center hover:bg-gray-200 dark:hover:bg-neutral-600 transition-colors"
+              <FontAwesomeIcon icon={faMagnifyingGlass} />
+            </Button>
+            <Button
+              variant="ghost"
+              size="icon"
+              onClick={() => navigate('/app/notifications')}
+              aria-label="Notifications"
               title="Notifications"
             >
-              <svg
-                className="w-4 h-4 text-gray-500 dark:text-neutral-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M15 17h5l-1.405-1.405A2.032 2.032 0 0118 14.158V11a6.002 6.002 0 00-4-5.659V5a2 2 0 10-4 0v.341C7.67 6.165 6 8.388 6 11v3.159c0 .538-.214 1.055-.595 1.436L4 17h5m6 0v1a3 3 0 11-6 0v-1m6 0H9"
-                />
-              </svg>
-            </a>
+              <FontAwesomeIcon icon={faBell} />
+            </Button>
           </div>
         </div>
 

--- a/src/ui/AppHeader.tsx
+++ b/src/ui/AppHeader.tsx
@@ -1,28 +1,23 @@
 /**
  * AppHeader — Sticky top bar.
  *
- * Left  : hamburger (mobile), current page title, org/team switcher
+ * Left  : hamburger (mobile), org/team switcher
  * Right : clock-in timer (if active), UserDropdown
+ *
+ * The page title lives in the body, not here — see ui/pageTitle.tsx.
  */
 import { faBars } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button, Text } from '@mieweb/ui';
+import { Button } from '@mieweb/ui';
 import React from 'react';
 
-import { useClockDocumentTitle } from '../lib/useClockDocumentTitle';
 import { useSidebar } from './AppLayout';
 import { ClockInHeaderTimer } from './ClockInHeaderTimer';
 import { OrgTeamSwitcher } from './OrgTeamSwitcher';
 import { UserDropdown } from './UserDropdown';
 
-interface AppHeaderProps {
-  title: string;
-}
-
-export const AppHeader: React.FC<AppHeaderProps> = ({ title }) => {
+export const AppHeader: React.FC = () => {
   const { openMobile } = useSidebar();
-
-  useClockDocumentTitle(title);
 
   return (
     <header className="app-header sticky top-0 z-40 flex shrink-0 flex-col justify-end border-b border-neutral-200 bg-white/85 backdrop-blur-md dark:border-neutral-800 dark:bg-neutral-900/85">
@@ -39,18 +34,6 @@ export const AppHeader: React.FC<AppHeaderProps> = ({ title }) => {
           >
             <FontAwesomeIcon icon={faBars} />
           </Button>
-
-          {/* Page title — yields space faster than the switcher (it is also in
-              the tab title, sidebar and bottom nav), but min-w stops it from
-              collapsing to nothing on narrow screens */}
-          <Text
-            as="h1"
-            size="base"
-            weight="semibold"
-            className="min-w-[3.5rem] shrink-[3] truncate tracking-tight"
-          >
-            {title}
-          </Text>
 
           {/* Current org/team scope */}
           <OrgTeamSwitcher />

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -3,8 +3,8 @@
  *
  * Composes three primitives:
  *   • Sidebar     — collapsible, icon-only or full width, drawer on mobile
- *   • AppHeader   — sticky top bar with title, theme toggle, user menu
- *   • <main>      — scrollable content area
+ *   • AppHeader   — sticky top bar with the org/team switcher and user menu
+ *   • <main>      — scrollable content area, led by <PageTitle />
  *
  * RouterContext is the single source of truth for pathname so any descendant
  * can read the current route or navigate without prop-drilling or an external
@@ -39,6 +39,7 @@ import { EnterprisePage } from '../features/enterprise/EnterprisePage';
 import { SIDEBAR_KEY, MESSAGES_PENDING_THREAD_KEY } from '../lib/constants';
 import { TeamProvider, useTeam } from '../lib/TeamContext';
 import { useBrand } from '../lib/useBrand';
+import { useClockDocumentTitle } from '../lib/useClockDocumentTitle';
 import { useSession } from '../lib/useSession';
 import { RefreshProvider } from '../lib/RefreshContext';
 import { ShiftReminderProvider } from '../features/notifications/ShiftReminderContext';
@@ -47,6 +48,7 @@ import { ReportIssueModal } from '../features/feedback/ReportIssueModal';
 import { AppHeader } from './AppHeader';
 import { BottomNav } from './BottomNav';
 import { CommandPalette } from './CommandPalette';
+import { PageTitleContext } from './pageTitle';
 import { PullToRefresh } from './PullToRefresh';
 import { RouterContext } from './router';
 import { SettingsPage } from './SettingsPage';
@@ -292,12 +294,24 @@ const AppLayoutContent: React.FC = () => {
       ? pathname.slice('/app/tickets/'.length)
       : null;
 
-  const route = profileSegment || ticketDetailId ? null : match(pathname);
-  const pageTitle = profileSegment
-    ? 'Profile'
-    : ticketDetailId
-      ? 'Ticket'
-      : (route?.title ?? 'App');
+  const route = profileUserId || profileUsername || ticketDetailId ? null : match(pathname);
+
+  // Shown in the browser tab. Covers the dynamic routes too, which have no
+  // registry entry.
+  const documentTitle =
+    profileUserId || profileUsername
+      ? 'Profile'
+      : ticketDetailId
+        ? 'Ticket'
+        : (route?.title ?? 'App');
+  useClockDocumentTitle(documentTitle);
+
+  // Rendered in the body by <PageTitle />. Null on profile and ticket detail:
+  // both already lead with a more specific heading of their own.
+  const pageTitle = route?.title ?? null;
+
+  const isTicketsRoute =
+    !profileUserId && !profileUsername && !ticketDetailId && pathname === '/app/tickets';
   const isMessagesPage = pathname === '/app/messages';
 
   const [messagesHasActiveChat, setMessagesHasActiveChat] = useState(false);
@@ -332,105 +346,113 @@ const AppLayoutContent: React.FC = () => {
 
   return (
     <RouterContext.Provider value={{ pathname, navigate }}>
-      <RefreshProvider globalRefreshHandlers={[refetchSession, refetchTeams, refetchClock]}>
-        <CommandPalette />
-        <ReportIssueModal open={reportIssueOpen} onClose={() => setReportIssueOpen(false)} />
-        <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
-        <ShiftReminderProvider>
-          <AppFeedbackContext.Provider
-            value={{
-              openReportIssue: () => setReportIssueOpen(true),
-              openFeedback: () => setFeedbackOpen(true),
-            }}
-          >
-            <MessagesActiveChatContext.Provider
-              value={{ setHasActiveChat: setMessagesHasActiveChat }}
+      <PageTitleContext.Provider value={pageTitle}>
+        <RefreshProvider globalRefreshHandlers={[refetchSession, refetchTeams, refetchClock]}>
+          <CommandPalette />
+          <ReportIssueModal open={reportIssueOpen} onClose={() => setReportIssueOpen(false)} />
+          <FeedbackModal open={feedbackOpen} onClose={() => setFeedbackOpen(false)} />
+          <ShiftReminderProvider>
+            <AppFeedbackContext.Provider
+              value={{
+                openReportIssue: () => setReportIssueOpen(true),
+                openFeedback: () => setFeedbackOpen(true),
+              }}
             >
-              <SidebarContext.Provider
-                value={{ isExpanded, isMobileOpen, toggle, openMobile, closeMobile }}
+              <MessagesActiveChatContext.Provider
+                value={{ setHasActiveChat: setMessagesHasActiveChat }}
               >
-                <div className="flex h-dvh overflow-hidden bg-neutral-50 font-sans text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
-                  {/* Mobile backdrop */}
-                  {isMobileOpen &&
-                    createPortal(
-                      <div
-                        className="fixed inset-0 z-45 bg-black/50 backdrop-blur-sm md:hidden"
-                        onClick={closeMobile}
-                        aria-hidden
-                      />,
-                      document.body,
-                    )}
+                <SidebarContext.Provider
+                  value={{ isExpanded, isMobileOpen, toggle, openMobile, closeMobile }}
+                >
+                  <div className="flex h-dvh overflow-hidden bg-neutral-50 font-sans text-neutral-900 dark:bg-neutral-950 dark:text-neutral-100">
+                    {/* Mobile backdrop */}
+                    {isMobileOpen &&
+                      createPortal(
+                        <div
+                          className="fixed inset-0 z-45 bg-black/50 backdrop-blur-sm md:hidden"
+                          onClick={closeMobile}
+                          aria-hidden
+                        />,
+                        document.body,
+                      )}
 
-                  {/* Foreground push notification banner (native iOS/Android) */}
-                  {foregroundNotif &&
-                    createPortal(
-                      <div
-                        onClick={() => {
-                          handleNotificationData(foregroundNotif.data);
-                          console.log(
-                            '[Banner] tapped, data:',
-                            JSON.stringify(foregroundNotif.data),
-                          );
-                          setForegroundNotif(null);
-                          if (dismissTimer.current) clearTimeout(dismissTimer.current);
-                        }}
-                        className="fixed top-4 left-1/2 -translate-x-1/2 z-9999 w-[90%] max-w-sm
+                    {/* Foreground push notification banner (native iOS/Android) */}
+                    {foregroundNotif &&
+                      createPortal(
+                        <div
+                          onClick={() => {
+                            handleNotificationData(foregroundNotif.data);
+                            console.log(
+                              '[Banner] tapped, data:',
+                              JSON.stringify(foregroundNotif.data),
+                            );
+                            setForegroundNotif(null);
+                            if (dismissTimer.current) clearTimeout(dismissTimer.current);
+                          }}
+                          className="fixed top-4 left-1/2 -translate-x-1/2 z-9999 w-[90%] max-w-sm
                                    bg-neutral-900 dark:bg-neutral-800 text-white rounded-2xl
                                    shadow-xl px-4 py-3 cursor-pointer flex flex-col gap-0.5
                                    border border-white/10"
-                        role="alert"
-                      >
-                        <span className="font-semibold text-sm leading-tight">
-                          {foregroundNotif.title}
-                        </span>
-                        <span className="text-xs text-neutral-300 leading-snug">
-                          {foregroundNotif.body}
-                        </span>
-                      </div>,
-                      document.body,
-                    )}
-
-                  <Sidebar />
-
-                  {/* Content column */}
-                  <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
-                    <AppHeader title={pageTitle} />
-                    <main
-                      ref={mainRef}
-                      className={`flex-1 overflow-auto ${isMessagesPage ? `h-full ${messagesHasActiveChat ? 'pb-0' : 'app-main-scroll'}` : 'app-main-scroll'} md:pb-0`}
-                    >
-                      <PullToRefresh>
-                        <div
-                          className={
-                            !profileSegment && !ticketDetailId && pathname === '/app/tickets'
-                              ? 'h-full w-full flex flex-col'
-                              : 'absolute w-0 h-0 overflow-hidden invisible pointer-events-none'
-                          }
+                          role="alert"
                         >
-                          <TicketsPage />
-                        </div>
-                        {profileUserId ? (
-                          <ProfilePage userId={profileUserId} />
-                        ) : profileUsername ? (
-                          <ProfilePage username={profileUsername} />
-                        ) : ticketDetailId ? (
-                          <TicketDetailPage ticketId={ticketDetailId} />
-                        ) : (
-                          route &&
-                          route.component !== TicketsPage &&
-                          React.createElement(route.component)
-                        )}
-                      </PullToRefresh>
-                    </main>
-                  </div>
+                          <span className="font-semibold text-sm leading-tight">
+                            {foregroundNotif.title}
+                          </span>
+                          <span className="text-xs text-neutral-300 leading-snug">
+                            {foregroundNotif.body}
+                          </span>
+                        </div>,
+                        document.body,
+                      )}
 
-                  {(!isMessagesPage || !messagesHasActiveChat) && <BottomNav />}
-                </div>
-              </SidebarContext.Provider>
-            </MessagesActiveChatContext.Provider>
-          </AppFeedbackContext.Provider>
-        </ShiftReminderProvider>
-      </RefreshProvider>
+                    <Sidebar />
+
+                    {/* Content column */}
+                    <div className="flex min-w-0 flex-1 flex-col overflow-hidden">
+                      <AppHeader />
+                      <main
+                        ref={mainRef}
+                        className={`flex-1 overflow-auto ${isMessagesPage ? `h-full ${messagesHasActiveChat ? 'pb-0' : 'app-main-scroll'}` : 'app-main-scroll'} md:pb-0`}
+                      >
+                        <PullToRefresh>
+                          {/* TicketsPage stays mounted to preserve its state, and
+                            is only hidden when another route is showing. It must
+                            not render a page title while hidden — it isn't the
+                            page — so the title is withheld from that instance. */}
+                          <PageTitleContext.Provider value={isTicketsRoute ? pageTitle : null}>
+                            <div
+                              className={
+                                isTicketsRoute
+                                  ? 'h-full w-full flex flex-col'
+                                  : 'absolute w-0 h-0 overflow-hidden invisible pointer-events-none'
+                              }
+                            >
+                              <TicketsPage />
+                            </div>
+                          </PageTitleContext.Provider>
+                          {profileUserId ? (
+                            <ProfilePage userId={profileUserId} />
+                          ) : profileUsername ? (
+                            <ProfilePage username={profileUsername} />
+                          ) : ticketDetailId ? (
+                            <TicketDetailPage ticketId={ticketDetailId} />
+                          ) : (
+                            route &&
+                            route.component !== TicketsPage &&
+                            React.createElement(route.component)
+                          )}
+                        </PullToRefresh>
+                      </main>
+                    </div>
+
+                    {(!isMessagesPage || !messagesHasActiveChat) && <BottomNav />}
+                  </div>
+                </SidebarContext.Provider>
+              </MessagesActiveChatContext.Provider>
+            </AppFeedbackContext.Provider>
+          </ShiftReminderProvider>
+        </RefreshProvider>
+      </PageTitleContext.Provider>
     </RouterContext.Provider>
   );
 };

--- a/src/ui/AppPage.tsx
+++ b/src/ui/AppPage.tsx
@@ -4,12 +4,15 @@
  * Centralises top-level padding, spacing, max content width (md:max-w-4xl
  * centered), and page-heading structure so routes render consistently.
  *
- * Intentionally minimal: no routing, no auth, no context reads.
+ * Renders <PageTitle /> so every page leads with its name without restating
+ * it — the name comes from AppLayout's ROUTES registry.
  */
 import React from 'react';
 
+import { PageTitle } from './pageTitle';
+
 interface AppPageProps {
-  /** Optional subtitle rendered below the header area. */
+  /** Optional subtitle rendered below the page title. */
   subtitle?: string;
   children: React.ReactNode;
   /**
@@ -42,7 +45,7 @@ export const AppPage: React.FC<AppPageProps> = ({
       fullWidth ? '' : ' md:mx-auto md:max-w-4xl'
     }${className ? ` ${className}` : ''}`}
   >
-    {subtitle && <p className="text-sm text-neutral-500 dark:text-neutral-400">{subtitle}</p>}
+    <PageTitle subtitle={subtitle} />
     {children}
   </div>
 );

--- a/src/ui/OrgTeamSwitcher.tsx
+++ b/src/ui/OrgTeamSwitcher.tsx
@@ -119,10 +119,7 @@ export const OrgTeamSwitcher: React.FC = () => {
             className="flex min-w-0 items-center gap-1.5 rounded-lg border border-neutral-200 bg-white px-2.5 py-1.5 text-sm font-medium text-neutral-700 transition-colors hover:bg-neutral-50 focus:outline-none focus:ring-2 focus:ring-blue-500/40 dark:border-neutral-700 dark:bg-neutral-800 dark:text-neutral-200 dark:hover:bg-neutral-700"
           >
             {selectedOrg && (
-              /* Below 360px (original iPhone SE) there isn't room for both
-                 segments plus a legible title, so the org yields; it is still
-                 the first row of the panel. Every current phone is >= 360. */
-              <span className="hidden min-w-0 items-center gap-1.5 min-[360px]:flex">
+              <span className="flex min-w-0 items-center gap-1.5">
                 <span
                   className="min-w-0 max-w-[4.5rem] truncate md:max-w-[9rem]"
                   title={selectedOrg.name}

--- a/src/ui/pageTitle.tsx
+++ b/src/ui/pageTitle.tsx
@@ -1,0 +1,50 @@
+/**
+ * pageTitle — The current page's name, rendered at the top of the body.
+ *
+ * Extracted into its own module so any component can consume the context
+ * without creating circular dependencies with AppLayout (same reason as
+ * router.ts).
+ *
+ * AppLayout is the single source of truth: it supplies the title straight
+ * from its ROUTES registry, so pages never restate their own name and the
+ * title follows automatically when a route is renamed. AppPage renders
+ * <PageTitle /> for every page, so pages opt in simply by using AppPage.
+ */
+import { Text } from '@mieweb/ui';
+import React, { createContext, useContext } from 'react';
+
+/**
+ * Null on routes with no registry title — profile and ticket detail render
+ * their own, more specific heading (the person's name, the ticket's title).
+ */
+export const PageTitleContext = createContext<string | null>(null);
+
+export const usePageTitle = () => useContext(PageTitleContext);
+
+interface PageTitleProps {
+  /** Optional supporting line rendered under the title. */
+  subtitle?: string;
+  /** Extra classes for pages with a non-standard header (e.g. Huddle's rail). */
+  className?: string;
+}
+
+export const PageTitle: React.FC<PageTitleProps> = ({ subtitle, className }) => {
+  const title = usePageTitle();
+
+  if (!title && !subtitle) return null;
+
+  return (
+    <div className={`page-title min-w-0${className ? ` ${className}` : ''}`}>
+      {title && (
+        <Text as="h1" size="2xl" weight="semibold" className="truncate tracking-tight">
+          {title}
+        </Text>
+      )}
+      {subtitle && (
+        <Text variant="muted" size="sm" className="mt-1">
+          {subtitle}
+        </Text>
+      )}
+    </div>
+  );
+};

--- a/tests/e2e/teams/profile-routing.spec.ts
+++ b/tests/e2e/teams/profile-routing.spec.ts
@@ -81,10 +81,9 @@ test.describe('Profile Routing', () => {
     // Must NOT be a bare root path like /member1
     expect(url).not.toMatch(/^http:\/\/[^/]+\/[^/]+$/);
 
-    // Profile page should be visible
-    await expect(page.getByRole('heading', { level: 1, name: 'Profile' })).toBeVisible({
-      timeout: 10000,
-    });
+    // Profile page should be visible — the hero card h1 shows the person's name
+    // (the nav bar no longer carries a "Profile" heading per the page-title-in-body refactor)
+    await expect(page.locator('h1.text-white').first()).toBeVisible({ timeout: 10000 });
   });
 
   // ── 2. Teams page: click member1 specifically → /app/profile/member1 ──────


### PR DESCRIPTION
Closes #421.

> **Stacked on #411 → #416** — review the last commit (`refactor: move the page title out of the nav bar…`); merge after those.

The nav bar carried the page title, which put the page's name as far from the page as possible. On Huddle it was also duplicated — "Huddle" in the nav bar *and* again above the composer.

Now every page leads with its own name in the body, and the nav bar carries only context and account controls.

## Changes

- **`ui/pageTitle.tsx`** (new) — `PageTitle` renders the page name as an `<h1>` (plus optional subtitle) via `@mieweb/ui` `Text`, reading the name from context. Own module, same reason as `router.ts`: no circular dep with `AppLayout`.
- **`AppPage.tsx`** — renders `<PageTitle />`, so all 19 pages that use it get a consistent heading with **no per-page markup**. Pages never restate their own name — it comes from `AppLayout`'s existing `ROUTES` registry, so renaming a route moves the heading with it.
- **`AppHeader.tsx`** — title and its prop removed.
- **`Huddle.tsx`** — hardcoded `<h1>Huddle</h1>` replaced with `<PageTitle />` in its sticky rail.

The title is still an `<h1>` with the same text, so existing heading assertions keep passing — it just moved from the header into `<main>`.

## Notes

- **Two concerns were one string.** `documentTitle` (the browser tab) still covers profile and ticket detail; the body title is `null` there, because both already lead with a better heading of their own — the person's name, the ticket's title.
- **A duplicate `<h1>` on every page.** `TicketsPage` stays mounted while hidden, and is hidden with `invisible` rather than `display:none`. Once it rendered a `PageTitle` it emitted a second `<h1>` carrying the *current* route's title everywhere — invisible, but in the a11y tree and enough to break level-1 heading locators. The hidden instance is now given no title. Also hoists the duplicated "is this the tickets route" condition into `isTicketsRoute`.
- **Drops the switcher's <360px org fallback** from #411. It only existed because the title competed for header width; with the title gone the org segment fits at 320px (switcher ends at 248 of 320), so the workaround goes.
- **`@mieweb/ui` migration**: Huddle's header controls move from raw `<button>`/`<svg>` to `Button` + FontAwesome. Its notifications control was an `<a href>` doing a full page load in an SPA — now uses the client router.

## Verification

Lint / typecheck / format clean. Unit 71/71. E2E 88 pass, 3 fail — `password-reset` ×2 (needs a mail service) and `logout-navigation` re-login; identical to the pre-existing baseline.

Swept all 15 routes (dashboard, huddle, work, tickets, timesheet, clock, teams, organization, media, messages, notifications, activity, settings, members, seeder) asserting **0 headings in the nav bar**, the title present **exactly once** in the body, and the tab title still carrying the page name. Profile and ticket detail keep their own headings. Checked full-height pages (Messages, Tickets, Huddle) still lay out, and the header at 320/360.
