### PR TITLE
Give Every Page One Standard Layout

### DIFF
--- a/src/features/activity/ActivityLogPage.tsx
+++ b/src/features/activity/ActivityLogPage.tsx
@@ -15,6 +15,7 @@ import { useTeam } from '../../lib/TeamContext';
 import { useSession } from '../../lib/useSession';
 import { useRefresh } from '../../lib/RefreshContext';
 import { AppPage } from '../../ui/AppPage';
+import { EmptyState } from '../../ui/EmptyState';
 
 // ─── Helpers ──────────────────────────────────────────────────────────────────
 
@@ -241,15 +242,11 @@ export const ActivityLogPage: React.FC = () => {
           </Text>
         </div>
       ) : filteredItems.length === 0 ? (
-        <div className="py-16 text-center">
-          <div className="mb-4 text-4xl" aria-hidden>
-            📋
-          </div>
-          <Text variant="muted">No activity yet</Text>
-          <Text variant="muted" size="sm" className="mt-1 block">
-            Events like clocking in and creating tickets will appear here.
-          </Text>
-        </div>
+        <EmptyState
+          icon="📋"
+          title="No activity yet"
+          description="Events like clocking in and creating tickets will appear here."
+        />
       ) : (
         <>
           <ul

--- a/src/features/clock/TimesheetPage.tsx
+++ b/src/features/clock/TimesheetPage.tsx
@@ -446,7 +446,7 @@ export const TimesheetPage: React.FC = () => {
   }
 
   return (
-    <AppPage className="flex h-full min-h-0 flex-col">
+    <AppPage width="wide" fill>
       {/* Fixed top: filters + summary stats */}
       <div className="flex shrink-0 flex-col gap-3">
         {/* Date range filter + Add Entry */}

--- a/src/features/media/MediaPage.tsx
+++ b/src/features/media/MediaPage.tsx
@@ -29,6 +29,7 @@ import {
 } from '../../lib/videoThumbnail';
 import { useSession } from '../../lib/useSession';
 import { AppPage } from '../../ui/AppPage';
+import { EmptyState } from '../../ui/EmptyState';
 import { ViewportOverlay } from '../../ui/ViewportOverlay';
 import { getDdpClient } from '../../lib/ddp';
 
@@ -584,17 +585,11 @@ export const MediaPage: React.FC = () => {
               <Spinner size="lg" label="Loading media…" />
             </div>
           ) : filteredItems.length === 0 ? (
-            <div className="flex flex-col items-center justify-center gap-3 py-20 text-center">
-              <FontAwesomeIcon
-                icon={faImage}
-                className="text-4xl text-neutral-300 dark:text-neutral-600"
-              />
-              <Text variant="muted" size="sm">
-                {filter === 'all'
-                  ? 'No media yet. Upload a video or image to get started.'
-                  : `No ${filter}s in your library.`}
-              </Text>
-            </div>
+            <EmptyState
+              icon={<FontAwesomeIcon icon={faImage} />}
+              title={filter === 'all' ? 'No media yet' : `No ${filter}s in your library`}
+              description={filter === 'all' ? 'Upload a video or image to get started.' : undefined}
+            />
           ) : (
             <div className="grid gap-3 auto-rows-[1fr] grid-cols-[repeat(auto-fill,minmax(240px,1fr))]">
               {filteredItems.map((item) => (

--- a/src/features/media/MediaPage.tsx
+++ b/src/features/media/MediaPage.tsx
@@ -523,7 +523,7 @@ export const MediaPage: React.FC = () => {
   };
 
   return (
-    <AppPage fullWidth>
+    <AppPage>
       {/* Toolbar */}
       <div className="mb-4 flex flex-wrap items-center gap-3">
         {/* Upload button */}

--- a/src/features/messages/MessagesPage.tsx
+++ b/src/features/messages/MessagesPage.tsx
@@ -619,7 +619,7 @@ export const MessagesPage: React.FC = () => {
 
   return (
     <>
-      <AppPage noPadding className="flex h-full w-full flex-col md:p-6">
+      <AppPage width="wide" fill>
         <div className="flex min-h-0 flex-1 gap-0 overflow-hidden md:gap-2">
           {/* ── Sidebar ─────────────────────────────────────────────────────── */}
           <Card

--- a/src/features/notifications/NotificationsPage.tsx
+++ b/src/features/notifications/NotificationsPage.tsx
@@ -29,6 +29,7 @@ import { MESSAGES_PENDING_THREAD_KEY } from '../../lib/constants';
 import { useSession } from '../../lib/useSession';
 import { useRouter } from '../../ui/router';
 import { AppPage } from '../../ui/AppPage';
+import { EmptyState } from '../../ui/EmptyState';
 import { useRefresh } from '../../lib/RefreshContext';
 import { useShiftReminder } from './ShiftReminderContext';
 
@@ -454,15 +455,11 @@ export const NotificationsPage: React.FC = () => {
           })}
         </ul>
       ) : (
-        <div className="py-16 text-center">
-          <div className="mb-4 text-4xl" aria-hidden>
-            🔔
-          </div>
-          <Text variant="muted">No notifications yet</Text>
-          <Text variant="muted" size="sm" className="mt-1 block">
-            Team invites and new messages will show up here.
-          </Text>
-        </div>
+        <EmptyState
+          icon="🔔"
+          title="No notifications yet"
+          description="Team invites and new messages will show up here."
+        />
       )}
 
       <Modal open={!!invitePreview} onOpenChange={(open) => !open && closeInviteModal()} size="lg">

--- a/src/features/org/OrganizationPage.tsx
+++ b/src/features/org/OrganizationPage.tsx
@@ -59,7 +59,7 @@ export const OrganizationPage: React.FC = () => {
     }
 
     return (
-      <AppPage fullWidth noPadding className="h-full">
+      <AppPage fill flush>
         <div className="flex h-full items-center justify-center px-6 text-center">
           <Text variant="muted" size="sm">
             No organization data available.
@@ -70,7 +70,7 @@ export const OrganizationPage: React.FC = () => {
   }
 
   return (
-    <AppPage fullWidth noPadding className="h-full min-h-0 space-y-0">
+    <AppPage fill flush>
       <div className="relative h-full min-h-0 w-full overflow-hidden">
         <div className="pointer-events-none absolute inset-x-0 bottom-0 z-10 px-3 py-3 md:px-4 md:py-4">
           {error && (

--- a/src/features/seeder/SeederPage.test.tsx
+++ b/src/features/seeder/SeederPage.test.tsx
@@ -31,6 +31,8 @@ vi.mock('./seedImport', () => ({
 }));
 
 vi.mock('@mieweb/ui', () => ({
+  // AppPage (which SeederPage renders) composes its classes with cn.
+  cn: (...args: unknown[]) => args.filter(Boolean).join(' '),
   Button: ({
     children,
     isLoading: _isLoading,

--- a/src/features/seeder/SeederPage.tsx
+++ b/src/features/seeder/SeederPage.tsx
@@ -121,7 +121,7 @@ export const SeederPage: React.FC = () => {
   };
 
   return (
-    <AppPage fullWidth className="max-w-7xl">
+    <AppPage width="wide">
       <div className="space-y-6">
         <div className="grid gap-5 lg:grid-cols-[300px_minmax(0,1fr)]">
           <div>

--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -1011,7 +1011,7 @@ export const TicketsPage: React.FC = () => {
     'ring-0 focus:ring-0 focus-visible:ring-0 focus:outline-none focus-visible:outline-none focus:border-blue-300 focus-visible:border-blue-300';
 
   return (
-    <AppPage fullWidth className="flex h-full min-h-0 flex-col">
+    <AppPage width="wide" fill>
       {/* ── Header: New Ticket + Search ── */}
       <div className="flex min-h-0 flex-1 flex-col gap-3">
         <div className="sticky top-0 z-20 -mx-4 border-b border-neutral-200 bg-neutral-50/95 px-4 py-2 backdrop-blur supports-backdrop-filter:bg-neutral-50/80 dark:border-neutral-800 dark:bg-neutral-950/95 dark:supports-backdrop-filter:bg-neutral-950/80 md:static md:z-auto md:mx-0 md:border-0 md:bg-transparent md:px-0 md:py-0">

--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -67,6 +67,7 @@ import { useClockToggle } from '../../lib/useClockToggle';
 import { useRefresh } from '../../lib/RefreshContext';
 import { useRouter } from '../../ui/router';
 import { AppPage } from '../../ui/AppPage';
+import { EmptyState } from '../../ui/EmptyState';
 import { UserAvatar } from '../../ui/UserAvatar';
 import { TimerToggleButton } from '../../ui/TimerToggleButton';
 import { AttachmentsPanel } from '../clock/AttachmentsPanel';
@@ -1355,15 +1356,18 @@ export const TicketsPage: React.FC = () => {
             ) : ticketsLoading ? (
               <TicketListSkeleton />
             ) : (
-              <div className="px-4 py-10 text-center">
-                <Text variant="muted" size="sm">
-                  {searchQuery
-                    ? 'No tickets match your search.'
+              <EmptyState
+                title={
+                  searchQuery
+                    ? 'No tickets match your search'
                     : statusFilter === 'open'
-                      ? 'No open tickets. Create one to get started!'
-                      : 'No closed tickets.'}
-                </Text>
-              </div>
+                      ? 'No open tickets'
+                      : 'No closed tickets'
+                }
+                description={
+                  !searchQuery && statusFilter === 'open' ? 'Create one to get started.' : undefined
+                }
+              />
             )}
           </div>
         </Card>

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -539,7 +539,7 @@ export const WorkPage: React.FC = () => {
   }
 
   return (
-    <AppPage fullWidth>
+    <AppPage width="wide">
       {/* ── Page Header: week nav + today + week range ── */}
       <div className="flex items-center justify-between gap-3">
         <Text weight="semibold" className="truncate">

--- a/src/features/timers/WorkPage.tsx
+++ b/src/features/timers/WorkPage.tsx
@@ -54,6 +54,7 @@ import { useRefresh } from '../../lib/RefreshContext';
 import { formatDuration } from '../../lib/timeUtils';
 import { useClockToggle } from '../../lib/useClockToggle';
 import { AppPage } from '../../ui/AppPage';
+import { EmptyState } from '../../ui/EmptyState';
 import { useRouter } from '../../ui/router';
 import { TimerToggleButton } from '../../ui/TimerToggleButton';
 
@@ -750,11 +751,7 @@ export const WorkPage: React.FC = () => {
 
       {/* ── Day View ── */}
       {dayEntries.length === 0 ? (
-        <div className="py-10 text-center">
-          <Text variant="muted" size="sm">
-            No timers for this day. Create one with "+".
-          </Text>
-        </div>
+        <EmptyState title="No timers for this day" description='Create one with "+".' />
       ) : (
         <Card padding="none">
           <Table>

--- a/src/pages/Huddle.tsx
+++ b/src/pages/Huddle.tsx
@@ -1,11 +1,11 @@
 import { faBell, faMagnifyingGlass } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
-import { Button } from '@mieweb/ui';
+import { Button, Input } from '@mieweb/ui';
 import { useState, useEffect } from 'react';
 import { HuddleComposer } from '../features/huddle/HuddleComposer';
 import { PostCard } from '../features/huddle/PostCard';
 import type { ComposerContent } from '../features/huddle/types';
-import { PageTitle } from '../ui/pageTitle';
+import { AppPage } from '../ui/AppPage';
 import { useRouter } from '../ui/router';
 import { useSession } from '@lib/useSession';
 import { useTeam } from '@lib/TeamContext';
@@ -172,132 +172,111 @@ export default function Huddle() {
   }
 
   return (
-    <div className="flex flex-col h-full bg-gray-50 dark:bg-neutral-900 min-h-screen">
-      {/* Sticky header section with both title and composer */}
-      <div className="sticky top-0 z-10 bg-white dark:bg-neutral-800 shrink-0">
-        {/* Header — the page name comes from the shared PageTitle */}
-        <div className="flex items-center justify-between gap-3 px-5 py-3 border-b border-gray-100 dark:border-neutral-700">
-          <PageTitle />
-          <div className="flex shrink-0 gap-2">
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => setShowSearch(!showSearch)}
-              aria-label="Search posts"
-              title="Search posts"
-            >
-              <FontAwesomeIcon icon={faMagnifyingGlass} />
-            </Button>
-            <Button
-              variant="ghost"
-              size="icon"
-              onClick={() => navigate('/app/notifications')}
-              aria-label="Notifications"
-              title="Notifications"
-            >
-              <FontAwesomeIcon icon={faBell} />
-            </Button>
-          </div>
+    <AppPage fill>
+      <div className="huddle flex h-full min-h-0 flex-col gap-4">
+        {/* Feed actions — the page name comes from AppPage's shared PageTitle */}
+        <div className="huddle-actions flex shrink-0 items-center justify-end gap-2">
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => setShowSearch(!showSearch)}
+            aria-label="Search posts"
+            title="Search posts"
+          >
+            <FontAwesomeIcon icon={faMagnifyingGlass} />
+          </Button>
+          <Button
+            variant="ghost"
+            size="icon"
+            onClick={() => navigate('/app/notifications')}
+            aria-label="Notifications"
+            title="Notifications"
+          >
+            <FontAwesomeIcon icon={faBell} />
+          </Button>
         </div>
 
-        {/* Search bar (shows when search button clicked) */}
         {showSearch && (
-          <div className="px-5 py-3 border-b border-gray-100 dark:border-neutral-700 bg-gray-50 dark:bg-neutral-900">
-            <div className="relative">
-              <input
-                type="text"
-                value={searchQuery}
-                onChange={(e) => setSearchQuery(e.target.value)}
-                placeholder="Search posts..."
-                className="w-full px-4 py-2 pl-10 text-sm bg-white dark:bg-neutral-800 border border-gray-200 dark:border-neutral-700 rounded-lg focus:outline-none focus:ring-2 focus:ring-indigo-500 dark:focus:ring-indigo-400 text-gray-900 dark:text-white placeholder-gray-400 dark:placeholder-neutral-500"
-                autoFocus
-              />
-              <svg
-                className="absolute left-3 top-2.5 w-4 h-4 text-gray-400"
-                fill="none"
-                viewBox="0 0 24 24"
-                stroke="currentColor"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M21 21l-6-6m2-5a7 7 0 11-14 0 7 7 0 0114 0z"
-                />
-              </svg>
-            </div>
-          </div>
-        )}
-
-        {/* Composer - part of sticky section */}
-        {selectedTeamId && (
-          <HuddleComposer
-            onPost={addPost}
-            userInitials={user ? getUserInitials(user.name) : 'U'}
-            userColor={user ? getUserColor(user.id) : 'indigo'}
+          <Input
+            label="Search posts"
+            hideLabel
+            value={searchQuery}
+            onChange={(e) => setSearchQuery(e.target.value)}
+            placeholder="Search posts…"
+            className="shrink-0"
+            autoFocus
           />
         )}
-      </div>
 
-      {/* Feed */}
-      <div className="flex-1 overflow-y-auto">
-        {!selectedTeamId && (
-          <div className="flex items-center justify-center py-16 px-4">
-            <p className="text-sm text-gray-500 dark:text-neutral-400">
-              Please select a team to view the huddle feed
-            </p>
+        {/* Composer stays put while the feed below it scrolls */}
+        {selectedTeamId && (
+          <div className="huddle-composer shrink-0">
+            <HuddleComposer
+              onPost={addPost}
+              userInitials={user ? getUserInitials(user.name) : 'U'}
+              userColor={user ? getUserColor(user.id) : 'indigo'}
+            />
           </div>
         )}
 
-        {selectedTeamId && (
-          <>
-            <div className="h-2 bg-gray-100 dark:bg-neutral-800 border-y border-gray-200 dark:border-neutral-700" />
+        {/* Feed */}
+        <div className="huddle-feed min-h-0 flex-1 overflow-y-auto">
+          {!selectedTeamId && (
+            <div className="flex items-center justify-center py-16 px-4">
+              <p className="text-sm text-gray-500 dark:text-neutral-400">
+                Please select a team to view the huddle feed
+              </p>
+            </div>
+          )}
 
-            {loading && (
-              <div className="flex items-center justify-center py-16">
-                <div className="w-8 h-8 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
-              </div>
-            )}
+          {selectedTeamId && (
+            <>
+              {loading && (
+                <div className="flex items-center justify-center py-16">
+                  <div className="w-8 h-8 border-2 border-indigo-500 border-t-transparent rounded-full animate-spin" />
+                </div>
+              )}
 
-            {error && (
-              <div className="flex items-center justify-center py-16 px-4">
-                <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
-              </div>
-            )}
+              {error && (
+                <div className="flex items-center justify-center py-16 px-4">
+                  <p className="text-sm text-red-500 dark:text-red-400">{error}</p>
+                </div>
+              )}
 
-            {!loading && !error && posts.length === 0 && (
-              <div className="flex items-center justify-center py-16 px-4">
-                <p className="text-sm text-gray-500 dark:text-neutral-400">
-                  No posts yet. Be the first to share!
-                </p>
-              </div>
-            )}
+              {!loading && !error && posts.length === 0 && (
+                <div className="flex items-center justify-center py-16 px-4">
+                  <p className="text-sm text-gray-500 dark:text-neutral-400">
+                    No posts yet. Be the first to share!
+                  </p>
+                </div>
+              )}
 
-            {!loading &&
-              !error &&
-              user &&
-              posts
-                .filter((post) => {
-                  if (!searchQuery.trim()) return true;
-                  const query = searchQuery.toLowerCase();
-                  return (
-                    post.content.text.toLowerCase().includes(query) ||
-                    post.userName?.toLowerCase().includes(query) ||
-                    post.ticketTitle?.toLowerCase().includes(query)
-                  );
-                })
-                .map((post) => (
-                  <PostCard
-                    key={post.id}
-                    post={post}
-                    currentUserId={user?.id ?? ''}
-                    canEdit={canEditPost(post)}
-                    canDelete={canDeletePost(post)}
-                  />
-                ))}
-          </>
-        )}
+              {!loading &&
+                !error &&
+                user &&
+                posts
+                  .filter((post) => {
+                    if (!searchQuery.trim()) return true;
+                    const query = searchQuery.toLowerCase();
+                    return (
+                      post.content.text.toLowerCase().includes(query) ||
+                      post.userName?.toLowerCase().includes(query) ||
+                      post.ticketTitle?.toLowerCase().includes(query)
+                    );
+                  })
+                  .map((post) => (
+                    <PostCard
+                      key={post.id}
+                      post={post}
+                      currentUserId={user?.id ?? ''}
+                      canEdit={canEditPost(post)}
+                      canDelete={canDeletePost(post)}
+                    />
+                  ))}
+            </>
+          )}
+        </div>
       </div>
-    </div>
+    </AppPage>
   );
 }

--- a/src/ui/AppPage.tsx
+++ b/src/ui/AppPage.tsx
@@ -1,51 +1,80 @@
 /**
- * AppPage — Shared layout wrapper for all authenticated app route pages.
+ * AppPage — The standard layout every authenticated route renders inside.
  *
- * Centralises top-level padding, spacing, max content width (md:max-w-4xl
- * centered), and page-heading structure so routes render consistently.
+ * One shape for every page: a centred content column with consistent padding,
+ * led by the shared <PageTitle />. Pages pick a column width; they never
+ * hand-roll padding or max-widths.
  *
- * Renders <PageTitle /> so every page leads with its name without restating
- * it — the name comes from AppLayout's ROUTES registry.
+ *   width="content"  (default) reading and forms — dashboard, settings, teams
+ *   width="wide"               data-dense grids — work, tickets, timesheet
+ *   fill                       content owns the remaining height and scrolls
+ *                              itself (chat, board, canvas)
+ *   flush                      content runs edge-to-edge; the title keeps the
+ *                              standard padding and alignment (canvases)
+ *
+ * The title is deliberately outside the `flush` escape hatch: a full-bleed
+ * canvas should not drag the page heading to the viewport edge with it.
  */
+import { cn } from '@mieweb/ui';
 import React from 'react';
 
-import { PageTitle } from './pageTitle';
+import { PageTitle, usePageTitle } from './pageTitle';
+
+export type PageWidth = 'content' | 'wide';
+
+const COLUMN: Record<PageWidth, string> = {
+  content: 'max-w-4xl',
+  wide: 'max-w-7xl',
+};
 
 interface AppPageProps {
-  /** Optional subtitle rendered below the page title. */
+  /** Content column width. Defaults to the reading-width column. */
+  width?: PageWidth;
+  /** Optional supporting line rendered under the page title. */
   subtitle?: string;
-  children: React.ReactNode;
-  /**
-   * When true, skip the default content max-width (full main column width).
-   * Use for dense data views (e.g. tickets table, work timers).
-   */
-  fullWidth?: boolean;
-  /**
-   * When true, remove the default page padding.
-   * Use for full-bleed pages where content should touch container edges.
-   */
-  noPadding?: boolean;
-  /**
-   * Optional extra classes applied to the outer wrapper div.
-   * Use sparingly — only for pages that require a non-standard layout
-   * (e.g. full-height flex containers for chat/canvas interfaces).
-   */
+  /** Content fills the remaining height and manages its own scrolling. */
+  fill?: boolean;
+  /** Content sits flush to the edges. Only for canvases (chat, org chart). */
+  flush?: boolean;
+  /** Extra classes for the outer wrapper. Use sparingly. */
   className?: string;
+  children: React.ReactNode;
 }
 
 export const AppPage: React.FC<AppPageProps> = ({
+  width = 'content',
   subtitle,
-  children,
+  fill,
+  flush,
   className,
-  fullWidth,
-  noPadding,
-}) => (
-  <div
-    className={`w-full space-y-6 ${noPadding ? 'p-0 md:p-0' : 'p-4 md:p-6'}${
-      fullWidth ? '' : ' md:mx-auto md:max-w-4xl'
-    }${className ? ` ${className}` : ''}`}
-  >
-    <PageTitle subtitle={subtitle} />
-    {children}
-  </div>
-);
+  children,
+}) => {
+  const title = usePageTitle();
+  // Profile and ticket detail have no registry title and lead with their own
+  // heading — they get no header block, and no gap where one would have been.
+  const hasHeader = Boolean(title || subtitle);
+  const column = cn('mx-auto w-full', COLUMN[width]);
+
+  return (
+    <div className={cn('app-page flex w-full flex-col', fill && 'h-full min-h-0', className)}>
+      {hasHeader && (
+        <div className={cn('shrink-0 px-4 pt-4 md:px-6 md:pt-6', !flush && column)}>
+          <PageTitle subtitle={subtitle} />
+        </div>
+      )}
+
+      <div
+        className={cn(
+          'w-full space-y-6',
+          hasHeader ? 'pt-6' : 'pt-4 md:pt-6',
+          // A filling page's children size themselves against this column, so
+          // it has to be the flex context they stretch inside.
+          fill && 'flex min-h-0 flex-1 flex-col',
+          !flush && cn(column, 'px-4 pb-4 md:px-6 md:pb-6'),
+        )}
+      >
+        {children}
+      </div>
+    </div>
+  );
+};

--- a/src/ui/EmptyState.tsx
+++ b/src/ui/EmptyState.tsx
@@ -1,0 +1,60 @@
+/**
+ * EmptyState — The standard "nothing here yet" block.
+ *
+ * A centred icon, a title and an optional supporting line, so every page says
+ * "nothing here" the same way.
+ *
+ * Centring is done twice on purpose. @mieweb/ui's Text defaults to
+ * align="left", which emits `text-left` and silently overrides a parent's
+ * `text-center` — the bug this component replaces, where the icon centred but
+ * the words sat against the left edge. So the column centres the elements and
+ * each Text sets its own alignment; either alone is not enough.
+ */
+import { cn, Text } from '@mieweb/ui';
+import React from 'react';
+
+interface EmptyStateProps {
+  /** Decorative icon or emoji. Hidden from screen readers. */
+  icon?: React.ReactNode;
+  /** What is empty, e.g. "No activity yet". */
+  title: string;
+  /** How it gets filled, e.g. "Events like clocking in will appear here." */
+  description?: string;
+  /** Optional call to action. */
+  action?: React.ReactNode;
+  className?: string;
+}
+
+export const EmptyState: React.FC<EmptyStateProps> = ({
+  icon,
+  title,
+  description,
+  action,
+  className,
+}) => (
+  <div
+    className={cn(
+      'empty-state flex flex-col items-center justify-center gap-3 px-4 py-16 text-center',
+      className,
+    )}
+  >
+    {icon && (
+      <div className="text-4xl text-neutral-300 dark:text-neutral-600" aria-hidden>
+        {icon}
+      </div>
+    )}
+
+    <div className="space-y-1">
+      <Text align="center" variant="muted" weight="medium">
+        {title}
+      </Text>
+      {description && (
+        <Text align="center" variant="muted" size="sm">
+          {description}
+        </Text>
+      )}
+    </div>
+
+    {action}
+  </div>
+);


### PR DESCRIPTION
> **Stacked on #411 → #416 → #417** — review the last two commits (`…one standard layout`, `…one standard empty state`).
>
> This branch **contains every commit from #411, #416 and #417**, so merging it alone ships all of the work. If you squash or rebase, those three won't auto-close — close them by hand. A merge commit closes them automatically.

Closes #422.

`AppPage` had no standard — just a grab-bag of escape hatches (`fullWidth`, `noPadding`, freeform `className`) that each page combined differently, and two pages skipped it entirely. **Five different layouts** were in use, so Huddle, Work, Organization, Media Library and Seeder each looked like a different app to Dashboard.

Organization was the worst: `fullWidth noPadding className="h-full min-h-0 space-y-0"` stripped the padding from the page title too — the heading sat jammed against the viewport edge with no gap above the chart.

## The standard

| | |
|---|---|
| `width="content"` *(default)* | Reading and forms — `max-w-4xl`, today's Dashboard |
| `width="wide"` | Data-dense grids — `max-w-7xl`, still centred, so nothing sprawls on an ultrawide |
| `fill` | Content owns the remaining height and scrolls itself |
| `flush` | Content runs edge-to-edge; **the title keeps standard padding** |

The title sits deliberately *outside* `flush`: a full-bleed canvas shouldn't drag the page heading to the viewport edge with it. That's the Organization fix, and it holds for any future canvas.

## Page assignments

- **wide** — Work, Tickets, Timesheet, Seeder, Messages: grids and tables that genuinely need the room.
- **content** — Media Library: a thumbnail grid reads better in the standard column than sprawling across an empty 1200px.
- **fill** — Tickets, Timesheet, Messages, Organization, Huddle.
- **flush** — Organization only; the pan/zoom chart is the one true canvas.

**Huddle joins the standard.** It was the only route rendering its own full-bleed shell, and it's really a feed, so it becomes a centred content column. Its search moves from a raw unlabelled `<input>` to `@mieweb/ui` `Input` with a hidden label (it had no accessible label at all), and a vestigial full-bleed spacer bar is dropped.

## Two things the refactor surfaced

- **`fill` must make the content column a flex context**, or children sized with `flex-1` have nothing to stretch against — Messages' chat collapsed to a stub until I fixed this.
- **`SeederPage`'s hand-written `@mieweb/ui` mock needed `cn`**, which `AppPage` now composes its classes with.

## Empty states

Empty states were hand-rolled per page, and half weren't actually centred: on Notifications and Activity Log the icon sat in the middle while the words hugged the left edge.

The cause isn't the page markup — both containers already set `text-center`. **`@mieweb/ui`'s `Text` defaults to `align="left"`**, so it emits `text-left` and silently overrides the parent's `text-center`. The emoji centred because it's a plain `div` that inherits alignment; the `Text` elements didn't. Media Library and ProfileFeed only looked right because they happened to use `flex items-center`, which centres the *element* rather than its text.

A shared **`EmptyState`** (centred icon, title, optional description) now covers the states with this bug — Notifications, Activity Log, Work ("No timers for this day") and Tickets — plus Media Library, which was the one already looking right and is now the same component rather than a coincidence.

It centres twice on purpose: the column centres the elements *and* each `Text` sets `align="center"`. Either alone is not enough, which is exactly how this drifted in the first place.

Titles the e2e suite asserts on (`No activity yet`, `No notifications yet`) are unchanged; longer one-liners are split into title + description so every page reads the same way.

## Verification

Lint / typecheck / format clean. Unit 71/71. E2E 88 pass, 3 fail — `password-reset` ×2 (needs a mail service) and `logout-navigation` re-login; identical to the pre-existing baseline.

Swept all 15 routes at **1440px and 390px**, asserting one title per page, no horizontal overflow, and that the title is never flush against the edge (16px on mobile, 24px+ on desktop). Checked each changed page in Chrome: Organization's title is padded with the chart still full-bleed, Messages' chat fills height with the composer anchored, Huddle is a centred feed, Media matches Dashboard, Work keeps its 7-day grid.
