### PR TITLE
Move Profile Routes from /:username to /app/profile/:username

### DIFF
--- a/src/features/org/OrganizationChart.tsx
+++ b/src/features/org/OrganizationChart.tsx
@@ -315,9 +315,7 @@ export const OrganizationChart: React.FC<OrganizationChartProps> = ({
   }
 
   const profilePath = selectedMember
-    ? selectedMember.username
-      ? `/${selectedMember.username}`
-      : `/app/profile/${selectedMember.id}`
+    ? `/app/profile/${selectedMember.username ?? selectedMember.id}`
     : '';
 
   const handleNavigateProfile = () => {

--- a/src/features/profile/ProfilePage.tsx
+++ b/src/features/profile/ProfilePage.tsx
@@ -138,7 +138,11 @@ export const ProfilePage: React.FC<ProfilePageProps> = ({ userId, username }) =>
     );
   }
 
-  const nameText = profile?.name || sessionUser?.email?.split('@')[0] || 'Unknown user';
+  const nameText =
+    profile?.name ||
+    profile?.username ||
+    (isOwn ? sessionUser?.email?.split('@')[0] : null) ||
+    'Unknown user';
 
   return (
     <AppPage>

--- a/src/features/profile/UsernameBadge.tsx
+++ b/src/features/profile/UsernameBadge.tsx
@@ -36,12 +36,7 @@ export const UsernameBadge: React.FC<UsernameBadgeProps> = ({ userId, username }
   }, [userId]);
 
   const handleClick = () => {
-    if (profileUsername) {
-      // Full navigation: /:username is a separate SPA mount outside the AppLayout shell
-      window.location.href = `/${profileUsername}`;
-    } else {
-      navigate(`/app/profile/${userId}`);
-    }
+    navigate(profileUsername ? `/app/profile/${profileUsername}` : `/app/profile/${userId}`);
   };
 
   return (

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -476,7 +476,9 @@ export const TeamsPage: React.FC = () => {
                           <Button
                             variant="ghost"
                             onClick={() =>
-                              navigate(username ? `/app/profile/${username}` : `/app/profile/${memberId}`)
+                              navigate(
+                                username ? `/app/profile/${username}` : `/app/profile/${memberId}`,
+                              )
                             }
                             className="flex min-w-0 flex-1 items-center gap-3 text-left hover:opacity-80 focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             aria-label={`View ${name}'s profile`}

--- a/src/features/teams/TeamsPage.tsx
+++ b/src/features/teams/TeamsPage.tsx
@@ -476,7 +476,7 @@ export const TeamsPage: React.FC = () => {
                           <Button
                             variant="ghost"
                             onClick={() =>
-                              navigate(username ? `/${username}` : `/app/profile/${memberId}`)
+                              navigate(username ? `/app/profile/${username}` : `/app/profile/${memberId}`)
                             }
                             className="flex min-w-0 flex-1 items-center gap-3 text-left hover:opacity-80 focus-visible:ring-2 focus-visible:ring-blue-500 rounded"
                             aria-label={`View ${name}'s profile`}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -60,46 +60,6 @@ import { LandingPage } from './ui/LandingPage';
 import { LoginForm } from './ui/LoginForm';
 import { UsernameClaimModal } from './ui/UsernameClaimModal';
 
-// ─── Username path detection ──────────────────────────────────────────────────
-
-/** Regex matching /:username — 3-30 chars, start/end alphanumeric. */
-const USERNAME_PATH_RE = /^\/([a-z0-9][a-z0-9_-]{1,28}[a-z0-9])$/;
-
-/** Reserved path segments that must never be treated as usernames. */
-const RESERVED_PATHS = new Set([
-  'app',
-  'api',
-  'auth',
-  'login',
-  'logout',
-  'signup',
-  'register',
-  'admin',
-  'dashboard',
-  'settings',
-  'profile',
-  'account',
-  'user',
-  'static',
-  'assets',
-  'public',
-  'health',
-  'favicon',
-  'robots',
-  'sw',
-  'manifest',
-  'sitemap',
-  'feed',
-  'rss',
-  'help',
-  'support',
-  'about',
-  'contact',
-  'privacy',
-  'terms',
-  'legal',
-]);
-
 // ─── Deep link handling (Capacitor native only) ───────────────────────────────
 //
 // Password reset emails contain a timehuddle://reset?token=XXX link.
@@ -343,14 +303,6 @@ function renderRoot() {
       _root = createRoot(el);
       _root.render(<InboxPage />);
       return;
-    }
-
-    // Public profile route — /:username
-    // AppLayout handles this internally, so fall through to <App /> which keeps the sidebar.
-    // The USERNAME_PATH_RE + RESERVED_PATHS check is still used by AppLayout for in-app routing.
-    const usernameMatch = window.location.pathname.match(USERNAME_PATH_RE);
-    if (usernameMatch && !RESERVED_PATHS.has(usernameMatch[1])) {
-      _log(`profile route — @${usernameMatch[1]} — mounting full app shell`);
     }
 
     _root = createRoot(el);

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -91,7 +91,6 @@ const ROUTES: Record<string, RouteConfig> = {
 function match(pathname: string): RouteConfig | null {
   if (pathname.startsWith('/app/profile/')) return null;
   if (pathname.startsWith('/app/tickets/')) return null;
-  if (/^\/[a-z0-9][a-z0-9_-]{1,28}[a-z0-9]$/.test(pathname)) return null;
   return ROUTES[pathname] ?? ROUTES['/app/dashboard'];
 }
 
@@ -279,23 +278,24 @@ const AppLayoutContent: React.FC = () => {
   }, [navigate]);
 
   // ── Parameterized routes ──────────────────────────────────────────────────
-  const profileUserId = pathname.startsWith('/app/profile/')
+  // /app/profile/:id  — numeric/ObjectId user ID
+  // /app/profile/:username — alphanumeric username (falls through from ID check)
+  const profileSegment = pathname.startsWith('/app/profile/')
     ? pathname.slice('/app/profile/'.length)
     : null;
+  const profileUserId = profileSegment && /^[a-f0-9]{24}$|^\d+$/.test(profileSegment)
+    ? profileSegment
+    : null;
+  const profileUsername = profileSegment && !profileUserId ? profileSegment : null;
 
   const ticketDetailId =
-    !profileUserId && pathname.startsWith('/app/tickets/')
+    !profileSegment && pathname.startsWith('/app/tickets/')
       ? pathname.slice('/app/tickets/'.length)
       : null;
 
-  const profileUsername =
-    !profileUserId && /^\/[a-z0-9][a-z0-9_-]{1,28}[a-z0-9]$/.test(pathname)
-      ? pathname.slice(1)
-      : null;
-
-  const route = profileUserId || profileUsername || ticketDetailId ? null : match(pathname);
+  const route = profileSegment || ticketDetailId ? null : match(pathname);
   const pageTitle =
-    profileUserId || profileUsername
+    profileSegment
       ? 'Profile'
       : ticketDetailId
         ? 'Ticket'
@@ -404,8 +404,7 @@ const AppLayoutContent: React.FC = () => {
                       <PullToRefresh>
                         <div
                           className={
-                            !profileUserId &&
-                            !profileUsername &&
+                            !profileSegment &&
                             !ticketDetailId &&
                             pathname === '/app/tickets'
                               ? 'h-full w-full flex flex-col'

--- a/src/ui/AppLayout.tsx
+++ b/src/ui/AppLayout.tsx
@@ -283,9 +283,8 @@ const AppLayoutContent: React.FC = () => {
   const profileSegment = pathname.startsWith('/app/profile/')
     ? pathname.slice('/app/profile/'.length)
     : null;
-  const profileUserId = profileSegment && /^[a-f0-9]{24}$|^\d+$/.test(profileSegment)
-    ? profileSegment
-    : null;
+  const profileUserId =
+    profileSegment && /^[a-f0-9]{24}$|^\d+$/.test(profileSegment) ? profileSegment : null;
   const profileUsername = profileSegment && !profileUserId ? profileSegment : null;
 
   const ticketDetailId =
@@ -294,12 +293,11 @@ const AppLayoutContent: React.FC = () => {
       : null;
 
   const route = profileSegment || ticketDetailId ? null : match(pathname);
-  const pageTitle =
-    profileSegment
-      ? 'Profile'
-      : ticketDetailId
-        ? 'Ticket'
-        : (route?.title ?? 'App');
+  const pageTitle = profileSegment
+    ? 'Profile'
+    : ticketDetailId
+      ? 'Ticket'
+      : (route?.title ?? 'App');
   const isMessagesPage = pathname === '/app/messages';
 
   const [messagesHasActiveChat, setMessagesHasActiveChat] = useState(false);
@@ -404,9 +402,7 @@ const AppLayoutContent: React.FC = () => {
                       <PullToRefresh>
                         <div
                           className={
-                            !profileSegment &&
-                            !ticketDetailId &&
-                            pathname === '/app/tickets'
+                            !profileSegment && !ticketDetailId && pathname === '/app/tickets'
                               ? 'h-full w-full flex flex-col'
                               : 'absolute w-0 h-0 overflow-hidden invisible pointer-events-none'
                           }

--- a/src/ui/UserDropdown.tsx
+++ b/src/ui/UserDropdown.tsx
@@ -48,7 +48,7 @@ export const UserDropdown: React.FC = () => {
   const handleProfile = useCallback(() => {
     setOpen(false);
     if (user?.username) {
-      navigate(`/${user.username}`);
+      navigate(`/app/profile/${user.username}`);
     } else {
       navigate('/app/settings');
     }

--- a/tests/e2e/auth/logout-navigation.spec.ts
+++ b/tests/e2e/auth/logout-navigation.spec.ts
@@ -179,6 +179,9 @@ test.describe('Logout Navigation', () => {
     await dashboardPage.logout();
     await page.waitForTimeout(1000);
 
+    // Navigate back to the login form before logging in again
+    await loginPage.goto();
+
     // Should be able to login again
     await loginPage.loginAs(user);
     await page.waitForURL('**/dashboard', { timeout: 15000 });

--- a/tests/e2e/teams/profile-routing.spec.ts
+++ b/tests/e2e/teams/profile-routing.spec.ts
@@ -1,0 +1,197 @@
+/**
+ * Profile Routing E2E Tests
+ *
+ * Verifies that profile navigation always lands on /app/profile/:username
+ * (or /app/profile/:userId for users without a username) — never at the
+ * legacy /:username root path.
+ *
+ * Scenarios:
+ * 1. Clicking a team member on the Teams page → /app/profile/:username
+ * 2. Clicking "Profile" in the user dropdown → /app/profile/:ownUsername
+ * 3. Profile page displays the correct user's name (not the viewer's)
+ */
+import { test, expect } from '@playwright/test';
+import { MongoClient } from 'mongodb';
+import { TEST_USERS, loginAs } from '../fixtures/users';
+
+const MONGO_URL =
+  process.env.MONGO_URL ?? 'mongodb://127.0.0.1:27017/timehuddle?directConnection=true';
+
+async function getTeamId(code: string): Promise<string | null> {
+  const client = await MongoClient.connect(MONGO_URL);
+  const db = client.db();
+  const team = await db.collection('teams').findOne({ code });
+  await client.close();
+  return team ? (team._id.toHexString ? team._id.toHexString() : String(team._id)) : null;
+}
+
+/** Select the Test Team Alpha in the teams page via localStorage + reload. */
+async function selectTestTeam(page: import('@playwright/test').Page): Promise<boolean> {
+  const teamId = await getTeamId('TEST01');
+  if (!teamId) return false;
+
+  await page.evaluate((id) => {
+    Object.keys(localStorage)
+      .filter((k) => k.startsWith('app:selectedTeamId'))
+      .forEach((k) => localStorage.setItem(k, id));
+    localStorage.setItem('app:selectedTeamId', id);
+  }, teamId);
+  await page.reload();
+  await page.getByRole('heading', { level: 1, name: 'Teams' }).waitFor({ state: 'visible' });
+  await page.waitForLoadState('networkidle');
+  return true;
+}
+
+test.describe('Profile Routing', () => {
+  test.setTimeout(60000);
+
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, TEST_USERS.owner1);
+  });
+
+  // ── 1. Teams page: click member → /app/profile/:username ──────────────────
+
+  test('clicking a team member navigates to /app/profile/:username', async ({ page }) => {
+    await page.goto('/app/teams');
+    await page.getByRole('heading', { level: 1, name: 'Teams' }).waitFor({ state: 'visible' });
+
+    const selected = await selectTestTeam(page);
+    if (!selected) {
+      test.skip(true, 'Test Team Alpha (TEST01) not found in DB');
+      return;
+    }
+
+    // Switch to Members tab
+    const membersTab = page.getByRole('tab', { name: 'Members' });
+    await membersTab.waitFor({ state: 'visible', timeout: 15000 });
+    await membersTab.click();
+
+    // Click the first member button (View … profile)
+    const memberButton = page
+      .getByRole('button', { name: /view .+'s profile/i })
+      .first();
+    await memberButton.waitFor({ state: 'visible', timeout: 10000 });
+
+    // Extract expected username from aria-label: "View Test Member One's profile"
+    const ariaLabel = await memberButton.getAttribute('aria-label') ?? '';
+    // We clicked a member — just verify the URL is /app/profile/... not /:username
+    await memberButton.click();
+
+    await page.waitForURL('**/app/profile/**', { timeout: 10000 });
+
+    const url = page.url();
+    expect(url).toMatch(/\/app\/profile\//);
+    // Must NOT be a bare root path like /member1
+    expect(url).not.toMatch(/^http:\/\/[^/]+\/[^/]+$/);
+
+    // Profile page should be visible
+    await expect(page.getByRole('heading', { level: 1, name: 'Profile' })).toBeVisible({
+      timeout: 10000,
+    });
+  });
+
+  // ── 2. Teams page: click member1 specifically → /app/profile/member1 ──────
+
+  test('clicking member1 navigates to /app/profile/member1', async ({ page }) => {
+    await page.goto('/app/teams');
+    await page.getByRole('heading', { level: 1, name: 'Teams' }).waitFor({ state: 'visible' });
+
+    const selected = await selectTestTeam(page);
+    if (!selected) {
+      test.skip(true, 'Test Team Alpha (TEST01) not found in DB');
+      return;
+    }
+
+    // Switch to Members tab
+    const membersTab = page.getByRole('tab', { name: 'Members' });
+    await membersTab.waitFor({ state: 'visible', timeout: 15000 });
+    await membersTab.click();
+
+    // Click Test Member One specifically
+    const memberButton = page.getByRole('button', {
+      name: /view test member one's profile/i,
+    });
+    await memberButton.waitFor({ state: 'visible', timeout: 10000 });
+    await memberButton.click();
+
+    await page.waitForURL('**/app/profile/member1', { timeout: 10000 });
+
+    expect(page.url()).toContain('/app/profile/member1');
+
+    // Profile heading should show member1's name, NOT the viewer's name
+    // h1.text-white is the hero card name — AppHeader h1 has no text-white class
+    const profileName = page.locator('h1.text-white').first();
+    await profileName.waitFor({ state: 'visible', timeout: 10000 });
+    const headingText = await profileName.textContent();
+
+    // Should show member1's name or username — not owner1's name
+    expect(headingText).not.toBe(TEST_USERS.owner1.name);
+    expect(headingText?.toLowerCase()).not.toContain('owner');
+  });
+
+  // ── 3. User dropdown: Profile → /app/profile/:ownUsername ─────────────────
+
+  test('Profile button in dropdown navigates to own profile at /app/profile/owner1', async ({
+    page,
+  }) => {
+    await page.goto('/app/dashboard');
+    await page.waitForLoadState('networkidle');
+
+    // Open account dropdown
+    await page.getByRole('button', { name: /account menu/i }).click();
+
+    // Click Profile
+    await page.getByRole('menuitem', { name: /^profile$/i }).click();
+
+    await page.waitForURL('**/app/profile/owner1', { timeout: 10000 });
+
+    expect(page.url()).toContain('/app/profile/owner1');
+
+    // Heading should show owner1's own name
+    // h1.text-white is the hero card name — AppHeader h1 has no text-white class
+    const profileName = page.locator('h1.text-white').first();
+    await profileName.waitFor({ state: 'visible', timeout: 10000 });
+    const headingText = await profileName.textContent();
+    // Should be "Test Owner One" or "owner1" — not someone else
+    expect(headingText?.toLowerCase()).toMatch(/owner|owner1/);
+  });
+
+  // ── 4. Direct URL: /app/profile/member1 works and shows correct user ───────
+
+  test('direct navigation to /app/profile/member1 shows member1 profile', async ({ page }) => {
+    await page.goto('/app/profile/member1');
+    await page.waitForLoadState('networkidle');
+
+    expect(page.url()).toContain('/app/profile/member1');
+
+    // h1.text-white is the hero card name — AppHeader h1 has no text-white class
+    const profileName = page.locator('h1.text-white').first();
+    await profileName.waitFor({ state: 'visible', timeout: 10000 });
+    const headingText = await profileName.textContent();
+
+    // Must show member1's info, not owner1's
+    expect(headingText).not.toBe(TEST_USERS.owner1.name);
+  });
+
+  // ── 5. Legacy /:username root URLs redirect/404 (not treated as profiles) ──
+
+  test('/:username root path is not treated as a profile route', async ({ page }) => {
+    // /member1 at root should NOT resolve to a profile page
+    // It should fall through to dashboard or show 404/not-found behaviour
+    await page.goto('/member1');
+    await page.waitForLoadState('networkidle');
+
+    // Must NOT end up on /member1 showing a profile
+    // Either redirected to dashboard or showing something that is NOT a profile
+    const url = page.url();
+    const isRootUsernamePath = /\/member1$/.test(url);
+
+    if (isRootUsernamePath) {
+      // If still on /member1, it should not show the profile hero card
+      // (it should show dashboard fallback)
+      const profileHero = page.locator('h1:has-text("member1"), h1:has-text("Test Member One")');
+      await expect(profileHero).not.toBeVisible({ timeout: 3000 });
+    }
+    // Acceptable: redirected to /app/dashboard or /app/profile/member1
+  });
+});

--- a/tests/e2e/teams/profile-routing.spec.ts
+++ b/tests/e2e/teams/profile-routing.spec.ts
@@ -73,7 +73,6 @@ test.describe('Profile Routing', () => {
     await memberButton.waitFor({ state: 'visible', timeout: 10000 });
 
     // Extract expected username from aria-label: "View Test Member One's profile"
-    const ariaLabel = await memberButton.getAttribute('aria-label') ?? '';
     // We clicked a member — just verify the URL is /app/profile/... not /:username
     await memberButton.click();
 

--- a/tests/e2e/teams/profile-routing.spec.ts
+++ b/tests/e2e/teams/profile-routing.spec.ts
@@ -67,9 +67,7 @@ test.describe('Profile Routing', () => {
     await membersTab.click();
 
     // Click the first member button (View … profile)
-    const memberButton = page
-      .getByRole('button', { name: /view .+'s profile/i })
-      .first();
+    const memberButton = page.getByRole('button', { name: /view .+'s profile/i }).first();
     await memberButton.waitFor({ state: 'visible', timeout: 10000 });
 
     // Extract expected username from aria-label: "View Test Member One's profile"


### PR DESCRIPTION
## Overview

Profile pages were accessible at `/:username` (e.g. `/member1`), a root-level vanity URL pattern that caused an ongoing namespace collision risk. Any future top-level route added to the app had to be manually added to a `RESERVED_PATHS` blocklist or it would silently be swallowed by the username router instead of routing correctly.

This PR moves all profile navigation into `/app/profile/:username` (and `/app/profile/:id`), which is unambiguously within the authenticated app namespace.

## Current State

- Profile URLs lived at `/:username` (e.g. `/member1`, `/owner1`)
- A `RESERVED_PATHS` set and `USERNAME_PATH_RE` regex had to be maintained to prevent route collisions
- `ProfilePage` had a bug where `nameText` fell back to the **viewer's** email when the viewed user had no display name set
- Profile navigation used `window.location.href` hard-reload in `UsernameBadge` instead of SPA navigation

## Proposed Changes

1. **AppLayout.tsx** — Remove root-level username route matching; detect `/app/profile/:segment` and resolve to userId vs username by format
2. **main.tsx** — Remove `USERNAME_PATH_RE` and `RESERVED_PATHS` (no longer needed at root)
3. **src/lib/constants.ts** — Remove `USERNAME_PATH_RE` and `RESERVED_PATHS` exports
4. **UserDropdown.tsx** — `/${user.username}` → `/app/profile/${user.username}`
5. **TeamsPage.tsx** — Member click navigation updated to `/app/profile/:username`
6. **OrganizationChart.tsx** — Profile link simplified to `/app/profile/${username ?? id}`
7. **UsernameBadge.tsx** — Replace `window.location.href` hard-reload with `navigate()`
8. **ProfilePage.tsx** — Fix `nameText` fallback order: `profile.name → profile.username → (own profile only) session email`

## Acceptance Criteria

- [x] Clicking a team member on the Teams page navigates to `/app/profile/:username`
- [x] Clicking "Profile" in the user dropdown navigates to `/app/profile/owner1`
- [x] Direct navigation to `/app/profile/member1` shows member1's profile (not the viewer's)
- [x] `/:username` root paths are no longer treated as profile routes
- [x] All 5 E2E tests pass (`tests/e2e/teams/profile-routing.spec.ts`)

