### PR TITLE
Fix ticket timer left running after auto-clockout (#436)

### DIFF
--- a/meteor-backend/scripts/find-orphaned-ticket-timers.js
+++ b/meteor-backend/scripts/find-orphaned-ticket-timers.js
@@ -1,0 +1,118 @@
+#!/usr/bin/env node
+/**
+ * Read-only report for #436 — finds ticket timer sessions stuck open
+ * (`timers.endTime === null`) that were orphaned by the auto-clockout bug
+ * (fixed in server/clock-core.js: stopActiveClock now closes running timers,
+ * same as manual clock.stop always did).
+ *
+ * A running timer is flagged ORPHANED when either:
+ *   - the user has no active clock event at all right now, or
+ *   - the user's current clock event started AFTER the timer did (the timer
+ *     is a leftover from a previous, already-ended shift).
+ *
+ * Makes no writes. Run this before deciding how to correct accumulated hours.
+ */
+
+import { MongoClient, ObjectId } from 'mongodb';
+
+const MONGO_URL = process.env.MONGO_URL || 'mongodb://127.0.0.1:27017/timehuddle';
+
+function formatHours(ms) {
+  return (ms / (1000 * 60 * 60)).toFixed(1);
+}
+
+function isValidId(id) {
+  return typeof id === 'string' && ObjectId.isValid(id);
+}
+
+async function main() {
+  const client = new MongoClient(MONGO_URL);
+  await client.connect();
+  console.log(`Connected to ${MONGO_URL}\n`);
+
+  try {
+    const db = client.db();
+    const now = Date.now();
+
+    const runningTimers = await db.collection('timers').find({ endTime: null }).toArray();
+
+    if (runningTimers.length === 0) {
+      console.log('No running timer sessions found. Nothing to report.');
+      return;
+    }
+
+    const userIds = [...new Set(runningTimers.map((t) => t.userId))];
+    const workItemIds = [...new Set(runningTimers.map((t) => t.workItemId).filter(isValidId))];
+
+    const [users, workItems, activeClockEvents] = await Promise.all([
+      db.collection('users').find({ _id: { $in: userIds } }).toArray(),
+      db.collection('workitems').find({ _id: { $in: workItemIds.map((id) => new ObjectId(id)) } }).toArray(),
+      db.collection('clockevents').find({ userId: { $in: userIds }, endTime: null }).toArray(),
+    ]);
+
+    const userById = new Map(users.map((u) => [String(u._id), u]));
+    const workItemById = new Map(workItems.map((w) => [String(w._id), w]));
+    const activeClockByUser = new Map(activeClockEvents.map((c) => [c.userId, c]));
+
+    const ticketIds = [...new Set(
+      [...workItemById.values()].map((w) => w.ticketId).filter(isValidId),
+    )];
+    const tickets = await db.collection('tickets')
+      .find({ _id: { $in: ticketIds.map((id) => new ObjectId(id)) } })
+      .toArray();
+    const ticketById = new Map(tickets.map((t) => [String(t._id), t]));
+
+    const rows = runningTimers.map((timer) => {
+      const user = userById.get(timer.userId);
+      const workItem = workItemById.get(timer.workItemId);
+      const ticket = workItem ? ticketById.get(workItem.ticketId) : null;
+      const activeClock = activeClockByUser.get(timer.userId);
+
+      const orphaned = !activeClock || activeClock.startTime > timer.startTime;
+
+      return {
+        timerId: String(timer._id),
+        userName: user?.profile?.name ?? '(unknown user)',
+        userEmail: user?.emails?.[0]?.address ?? '(unknown email)',
+        ticketTitle: ticket?.title ?? '(unknown ticket)',
+        ticketId: workItem?.ticketId ?? '(unknown)',
+        startTime: new Date(timer.startTime).toISOString(),
+        elapsedHours: formatHours(now - timer.startTime),
+        currentlyClockedIn: Boolean(activeClock),
+        orphaned,
+      };
+    });
+
+    rows.sort((a, b) => Number(b.elapsedHours) - Number(a.elapsedHours));
+
+    console.log(`Found ${rows.length} running timer session(s):\n`);
+    for (const row of rows) {
+      const flag = row.orphaned ? '⚠️  ORPHANED' : '   running';
+      console.log(`${flag}  ${row.elapsedHours}h elapsed`);
+      console.log(`    Ticket:      ${row.ticketTitle} (${row.ticketId})`);
+      console.log(`    User:        ${row.userName} <${row.userEmail}>`);
+      console.log(`    Timer id:    ${row.timerId}`);
+      console.log(`    Started:     ${row.startTime}`);
+      console.log(`    Clocked in:  ${row.currentlyClockedIn ? 'yes' : 'no'}`);
+      console.log('');
+    }
+
+    const orphanedCount = rows.filter((r) => r.orphaned).length;
+    console.log('=== Summary ===');
+    console.log(`Total running timers:    ${rows.length}`);
+    console.log(`Orphaned (bug-affected): ${orphanedCount}`);
+    console.log(`Legitimately running:    ${rows.length - orphanedCount}`);
+
+    if (orphanedCount > 0) {
+      console.log('\nThis is a read-only report — no documents were modified.');
+      console.log('Decide a correct cutoff time per session before writing a fix-up script.');
+    }
+  } finally {
+    await client.close();
+  }
+}
+
+main().catch((error) => {
+  console.error('Report failed:', error);
+  process.exitCode = 1;
+});

--- a/meteor-backend/server/clock-core.js
+++ b/meteor-backend/server/clock-core.js
@@ -7,6 +7,7 @@
  * the close-out. No Meteor method/DDP context here — plain async helpers.
  */
 import { ClockEvents, ClockBreaks } from './collections';
+import { closeAllForUser } from './timer-core';
 
 /** 20-minute threshold: breaks >= this are non-compensable meal breaks (deducted). */
 export const MEAL_BREAK_THRESHOLD_SECONDS = 20 * 60;
@@ -195,15 +196,19 @@ export function toPublicClockEvent(event, breaks) {
 }
 
 /**
- * Close the user's active clock event in a team: auto-classify any open break,
- * compute accumulatedTime (span minus meal breaks), and set endTime. Returns the
- * updated event doc, or null when there was nothing open. Mirrors ClockService.stop.
+ * Close the user's active clock event in a team: close any running ticket
+ * timers, auto-classify any open break, compute accumulatedTime (span minus
+ * meal breaks), and set endTime. Returns the updated event doc, or null when
+ * there was nothing open. Mirrors ClockService.stop / clock.stop.
  */
 export async function stopActiveClock(userId, teamId, now = Date.now()) {
   const event = await ClockEvents.findOneAsync({ userId, teamId, endTime: null });
   if (!event) return null;
 
   const eventId = event._id.toHexString();
+
+  // Close any running timer sessions for this user (mirrors clock.stop).
+  await closeAllForUser(userId, now);
 
   const openBreak = await ClockBreaks.findOneAsync({ clockEventId: eventId, endTime: null });
   if (openBreak) {

--- a/meteor-backend/server/org-helpers.js
+++ b/meteor-backend/server/org-helpers.js
@@ -1,3 +1,4 @@
+import { Meteor } from 'meteor/meteor';
 import { MongoInternals } from 'meteor/mongo';
 import { rawDb, isValidId } from './collections';
 
@@ -10,56 +11,93 @@ const DEFAULT_ENTERPRISE_NAME = process.env.DEFAULT_ENTERPRISE_NAME || 'Default 
 
 const ROLE_RANK = { member: 1, admin: 2, owner: 3 };
 
+const DUPLICATE_KEY_ERROR_CODE = 11000;
+
+// Upsert-by-slug relies on these unique indexes to make first-writer-wins
+// atomic across concurrent requests (e.g. two browsers hitting takeOwnership
+// on a fresh install at the same time). Without them, concurrent findOne+
+// insertOne calls can each observe "not found" and create duplicate default
+// enterprise/organization documents.
+Meteor.startup(async () => {
+  try {
+    await rawDb().collection('enterprises').createIndex(
+      { slug: 1 },
+      { name: 'unique_enterprise_slug', unique: true },
+    );
+    await rawDb().collection('organizations').createIndex(
+      { slug: 1 },
+      { name: 'unique_organization_slug', unique: true },
+    );
+  } catch (error) {
+    console.error('[org-helpers] failed to create default org/enterprise indexes:', error);
+  }
+});
+
 async function ensureDefaultEnterprise() {
   const db = rawDb();
-  const existing = await db.collection('enterprises').findOne({ slug: DEFAULT_ENTERPRISE_SLUG });
-  if (existing) return existing;
-
   const now = new Date();
-  const enterprise = {
-    _id: new ObjectId(),
-    name: DEFAULT_ENTERPRISE_NAME,
-    slug: DEFAULT_ENTERPRISE_SLUG,
-    owners: [],
-    admins: [],
-    createdAt: now,
-    updatedAt: now,
-  };
-  await db.collection('enterprises').insertOne(enterprise);
-  return enterprise;
+
+  try {
+    await db.collection('enterprises').updateOne(
+      { slug: DEFAULT_ENTERPRISE_SLUG },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          name: DEFAULT_ENTERPRISE_NAME,
+          slug: DEFAULT_ENTERPRISE_SLUG,
+          owners: [],
+          admins: [],
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      { upsert: true },
+    );
+  } catch (error) {
+    // Lost the race to another concurrent upsert on the same unique slug — fine, fall through to read it.
+    if (error?.code !== DUPLICATE_KEY_ERROR_CODE) throw error;
+  }
+
+  return db.collection('enterprises').findOne({ slug: DEFAULT_ENTERPRISE_SLUG });
 }
 
 export async function ensureDefaultOrganization() {
   const db = rawDb();
   const defaultEnterprise = await ensureDefaultEnterprise();
-  const existing = await db.collection('organizations').findOne({ slug: DEFAULT_ORG_KEY });
+  const now = new Date();
 
-  if (existing) {
-    const updates = {};
-    if (!existing.enterpriseId) updates.enterpriseId = defaultEnterprise._id.toHexString();
-    if (existing.allowAutoJoin === undefined) updates.allowAutoJoin = true;
-    if (Object.keys(updates).length > 0) {
-      updates.updatedAt = new Date();
-      await db.collection('organizations').updateOne({ _id: existing._id }, { $set: updates });
-      return (await db.collection('organizations').findOne({ _id: existing._id })) ?? existing;
-    }
-    return existing;
+  try {
+    await db.collection('organizations').updateOne(
+      { slug: DEFAULT_ORG_KEY },
+      {
+        $setOnInsert: {
+          _id: new ObjectId(),
+          enterpriseId: defaultEnterprise._id.toHexString(),
+          slug: DEFAULT_ORG_KEY,
+          name: DEFAULT_ORG_NAME,
+          owners: [],
+          admins: [],
+          allowAutoJoin: true,
+          createdAt: now,
+          updatedAt: now,
+        },
+      },
+      { upsert: true },
+    );
+  } catch (error) {
+    if (error?.code !== DUPLICATE_KEY_ERROR_CODE) throw error;
   }
 
-  const now = new Date();
-  const org = {
-    _id: new ObjectId(),
-    enterpriseId: defaultEnterprise._id.toHexString(),
-    slug: DEFAULT_ORG_KEY,
-    name: DEFAULT_ORG_NAME,
-    owners: [],
-    admins: [],
-    allowAutoJoin: true,
-    createdAt: now,
-    updatedAt: now,
-  };
-  await db.collection('organizations').insertOne(org);
-  return org;
+  const existing = await db.collection('organizations').findOne({ slug: DEFAULT_ORG_KEY });
+  const updates = {};
+  if (!existing.enterpriseId) updates.enterpriseId = defaultEnterprise._id.toHexString();
+  if (existing.allowAutoJoin === undefined) updates.allowAutoJoin = true;
+  if (Object.keys(updates).length > 0) {
+    updates.updatedAt = new Date();
+    await db.collection('organizations').updateOne({ _id: existing._id }, { $set: updates });
+    return (await db.collection('organizations').findOne({ _id: existing._id })) ?? existing;
+  }
+  return existing;
 }
 
 async function syncLegacyRoleArrays(orgId, userId, role) {

--- a/meteor-backend/tests/clock-timer-integration.test.ts
+++ b/meteor-backend/tests/clock-timer-integration.test.ts
@@ -1,0 +1,149 @@
+/**
+ * Clock ↔ ticket-timer integration — wormhole REST tests.
+ *
+ * Covers the interaction between clock in/out/pause/resume and the ticket
+ * timer session in the `timers` collection: clocking out must close any
+ * running ticket timer, and going on break must pause it and restart a new
+ * session on resume (see #436 — auto-clockout previously left timers running).
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import {
+  createUserAndGetJwt,
+  wormhole,
+  getDb,
+  closeDb,
+  purgeUser,
+  ObjectId,
+} from './helpers';
+
+const USER = { name: 'Clock Timer User', email: 'wh-clock-timer-user@test.dev', password: 'Password1!' };
+
+let jwt: string;
+let userId: string;
+let teamId: string;
+let ticketId: string;
+
+async function startTicketTimer() {
+  const today = new Date().toISOString().split('T')[0];
+  const res = await wormhole<{ entry: { id: string }; session: { id: string } | null }>(
+    'timers.createEntry',
+    { ticketId, date: today, startNow: true, notifyAdmins: false },
+    jwt,
+  );
+  expect(res.ok).toBe(true);
+  return res.result.entry.id; // workItemId
+}
+
+beforeAll(async () => {
+  await purgeUser(USER.email);
+  const auth = await createUserAndGetJwt(USER);
+  jwt = auth.jwt;
+
+  const db = await getDb();
+  userId = String((await db.collection('users').findOne({ 'emails.address': USER.email }))!._id);
+
+  const teamDoc = {
+    _id: new ObjectId(),
+    name: 'WH Clock Timer Team',
+    members: [userId],
+    admins: [userId],
+    code: 'WHCLKTMR',
+    isPersonal: false,
+    createdAt: new Date(),
+  };
+  await db.collection('teams').insertOne(teamDoc);
+  teamId = teamDoc._id.toHexString();
+
+  const ticketDoc = {
+    _id: new ObjectId(),
+    teamId,
+    title: 'Clock Timer Test Ticket',
+    status: 'open',
+    priority: 'medium',
+    createdBy: userId,
+    assignedTo: userId,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  };
+  await db.collection('tickets').insertOne(ticketDoc);
+  ticketId = ticketDoc._id.toHexString();
+});
+
+afterAll(async () => {
+  const db = await getDb();
+  await db.collection('teams').deleteMany({ code: 'WHCLKTMR' });
+  await db.collection('tickets').deleteMany({ teamId });
+  await db.collection('workitems').deleteMany({ userId });
+  await db.collection('timers').deleteMany({ userId });
+  await db.collection('clockevents').deleteMany({ teamId });
+  await db.collection('clockbreaks').deleteMany({});
+  await purgeUser(USER.email);
+  await closeDb();
+});
+
+describe('clock out stops the running ticket timer', () => {
+  it('closes the running timer session when clocking out', async () => {
+    const db = await getDb();
+
+    const clockIn = await wormhole('clock.start', { teamId }, jwt);
+    expect(clockIn.ok).toBe(true);
+
+    const workItemId = await startTicketTimer();
+    const runningBefore = await db.collection('timers').findOne({ userId, workItemId, endTime: null });
+    expect(runningBefore).not.toBeNull();
+
+    const clockOut = await wormhole<{ endTime: number | null }>('clock.stop', { teamId }, jwt);
+    expect(clockOut.ok).toBe(true);
+    expect(clockOut.result.endTime).not.toBeNull();
+
+    const runningAfter = await db.collection('timers').findOne({ userId, workItemId, endTime: null });
+    expect(runningAfter).toBeNull();
+
+    const closedSession = await db.collection('timers').findOne({ userId, workItemId, endTime: { $ne: null } });
+    expect(closedSession).not.toBeNull();
+    expect(closedSession!.durationSeconds).toBeGreaterThanOrEqual(0);
+  });
+});
+
+describe('break pauses and resumes the running ticket timer', () => {
+  it('pauses the ticket timer on break start and restarts a new session on resume', async () => {
+    const db = await getDb();
+
+    const clockIn = await wormhole('clock.start', { teamId }, jwt);
+    expect(clockIn.ok).toBe(true);
+
+    const workItemId = await startTicketTimer();
+    const runningBeforeBreak = await db
+      .collection('timers')
+      .findOne({ userId, workItemId, endTime: null });
+    expect(runningBeforeBreak).not.toBeNull();
+    const firstSessionId = String(runningBeforeBreak!._id);
+
+    // Going on break should pause (close) the running ticket timer.
+    const pause = await wormhole('clock.pause', { teamId }, jwt);
+    expect(pause.ok).toBe(true);
+
+    const noneRunningOnBreak = await db.collection('timers').findOne({ userId, endTime: null });
+    expect(noneRunningOnBreak).toBeNull();
+
+    const firstSessionClosed = await db.collection('timers').findOne({ _id: new ObjectId(firstSessionId) });
+    expect(firstSessionClosed!.endTime).not.toBeNull();
+
+    // Resuming should restart a fresh session for the same work item.
+    const resume = await wormhole('clock.resume', { teamId }, jwt);
+    expect(resume.ok).toBe(true);
+
+    const runningAfterResume = await db
+      .collection('timers')
+      .findOne({ userId, workItemId, endTime: null });
+    expect(runningAfterResume).not.toBeNull();
+    expect(String(runningAfterResume!._id)).not.toBe(firstSessionId);
+
+    // Clean up: clocking out should close the resumed session too.
+    const clockOut = await wormhole<{ endTime: number | null }>('clock.stop', { teamId }, jwt);
+    expect(clockOut.ok).toBe(true);
+
+    const runningAfterClockOut = await db.collection('timers').findOne({ userId, endTime: null });
+    expect(runningAfterClockOut).toBeNull();
+  });
+});

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -16,7 +16,34 @@ import { createHash } from 'crypto';
 
 const MONGO_URL =
   process.env.MONGO_URL ?? 'mongodb://127.0.0.1:27017/timehuddle_test?replicaSet=rs0';
+const BACKEND_URL = process.env.API_TARGET ?? 'http://localhost:3101';
 const PASSWORD = 'TestPass1!';
+
+/**
+ * Poll the Meteor backend's /health endpoint until it responds.
+ *
+ * Guards against a race where the backend was just (re)started — e.g. via
+ * `pm2 restart all` — and is still finishing DDP/Mongo initialization when
+ * the suite begins. Without this, the first test(s) to log in can hang on
+ * the DDP handshake past the login timeout (see activity-log.spec.ts flake).
+ */
+async function waitForBackend(url: string, timeoutMs = 30000): Promise<void> {
+  const deadline = Date.now() + timeoutMs;
+  let lastError: unknown;
+  while (Date.now() < deadline) {
+    try {
+      const res = await fetch(`${url}/health`);
+      if (res.ok) return;
+      lastError = new Error(`/health returned ${res.status}`);
+    } catch (err) {
+      lastError = err;
+    }
+    await new Promise((resolve) => setTimeout(resolve, 500));
+  }
+  throw new Error(
+    `Meteor backend at ${url} did not become healthy within ${timeoutMs}ms: ${String(lastError)}`,
+  );
+}
 
 const SEED_USERS = [
   { email: 'owner1@test.local', name: 'Test Owner One', username: 'owner1', role: 'owner' },
@@ -38,6 +65,8 @@ const SEED_USERS = [
 ] as const;
 
 export default async function globalSetup(): Promise<void> {
+  await waitForBackend(BACKEND_URL);
+
   const client = await MongoClient.connect(MONGO_URL);
   const db = client.db();
 

--- a/tests/e2e/timesheet/timesheet-calculation-fixes.spec.ts
+++ b/tests/e2e/timesheet/timesheet-calculation-fixes.spec.ts
@@ -111,6 +111,12 @@ test.describe('Timesheet calculation fixes', () => {
       const timesheetPage = new TimesheetPage(page);
       await timesheetPage.goto();
 
+      // Scope to the team this seeded session belongs to — the page
+      // defaults to the user's personal workspace (sorted first), not
+      // necessarily "Test Team Alpha".
+      await page.getByRole('button', { name: /Switch organization and team/i }).click();
+      await page.getByRole('menuitem', { name: 'Test Team Alpha' }).click();
+
       // Custom range tightly bounding just this seeded session, so no other
       // test's "now"-relative clock in/out data can leak into the totals.
       const rangeStart = new Date(sessionStart);
@@ -188,6 +194,17 @@ test.describe('Timesheet calculation fixes', () => {
         await loginAs(page, TEST_USERS.member5);
         const timesheetPage = new TimesheetPage(page);
         await timesheetPage.goto();
+
+        // The Timesheet page scopes sessions to the currently selected team,
+        // which defaults to the user's personal workspace (sorted first) —
+        // not necessarily "Test Team Alpha" where these seeded sessions live.
+        // Select it explicitly so this doesn't depend on default-team
+        // selection order, which drifts as member5 accumulates other teams
+        // (e.g. a personal team auto-created by an earlier login) across the
+        // suite.
+        await page.getByRole('button', { name: /Switch organization and team/i }).click();
+        await page.getByRole('menuitem', { name: 'Test Team Alpha' }).click();
+
         await applyCustomRange(page, '2026-01-14', '2026-01-17');
 
         // Both rows should read "Jan 15, 2026" — never "Jan 16, 2026".


### PR DESCRIPTION
## Summary

- Auto-clockout (the 8h-agreed and missed-reminder Agenda jobs) called `stopActiveClock`, which only closed the `ClockEvents` doc — unlike manual `clock.stop`, it never closed a running ticket timer. Any timer left running when a shift ended automatically instead of via a manual click was orphaned indefinitely, matching the symptom in #436 (ticket timer keeps ticking even across later clock in/out cycles).
- While reproducing this, found and fixed a related race: `enterprises.takeOwnership`'s "first writer wins" guarantee could be defeated by a concurrent check-then-insert race in `ensureDefaultEnterprise`/`ensureDefaultOrganization`, letting two concurrent claims both succeed. Added unique indexes + atomic upsert.
- Also picked up two in-progress e2e test fixes: waiting for the backend `/health` check in `global-setup`, and explicit team-scoping in the timesheet calculation spec so it doesn't depend on which team the page defaults to.

## Test plan

- [x] `stopActiveClock` now calls `closeAllForUser`, mirroring `clock.stop` — added `meteor-backend/tests/clock-timer-integration.test.ts` covering both clock-out and break pause/resume against the `timers` collection.
- [x] Added `meteor-backend/scripts/find-orphaned-ticket-timers.js` — a read-only report to find any already-orphaned timer sessions in a live DB (verified against 9 synthetic edge cases: no clock event, stale-across-shift, boundary timestamps, missing/malformed ticket/work-item/user references, duplicate running timers per user).
- [x] `enterprises.takeOwnership` atomicity fix — re-ran the previously-flaky `is atomic - first writer wins in race condition` test 5x in a row, passes reliably.
- [x] Full backend suite: 101/101 passing.
- [x] `timesheet-calculation-fixes.spec.ts` — ran twice end-to-end against the real app (Playwright), both passing.
- [x] Lint + typecheck clean on all changed files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)