### PR TITLE
Fix password reset emails failing due to unbracketed IPv6 MAIL_URL

### DIFF
--- a/meteor-backend/server/mail-url.js
+++ b/meteor-backend/server/mail-url.js
@@ -1,0 +1,32 @@
+/**
+ * Mail URL builder — pure function, no Meteor imports, so it can be unit
+ * tested directly (see tests/mail-url.test.ts) without booting the full
+ * Meteor server.
+ *
+ * Builds the `smtp://` connection string Meteor's `email` package (used by
+ * Accounts.sendResetPasswordEmail) expects, from discrete SMTP_* env vars.
+ */
+
+/**
+ * IPv6 literals (e.g. "::1") must be bracketed inside a URL — otherwise
+ * `new URL()` throws ERR_INVALID_URL and the email package silently fails
+ * to send (surfaced to the user as "Failed to send reset email").
+ */
+function bracketIfIPv6(host) {
+  return host.includes(':') && !host.startsWith('[') ? `[${host}]` : host;
+}
+
+/**
+ * @param {{ SMTP_HOST?: string, SMTP_PORT?: string, SMTP_USER?: string, SMTP_PASS?: string, SMTP_SECURE?: string }} env
+ * @returns {string | undefined} the MAIL_URL, or undefined if SMTP_HOST isn't set
+ */
+export function buildMailUrl(env) {
+  if (!env.SMTP_HOST) return undefined;
+  const smtpHost = bracketIfIPv6(env.SMTP_HOST);
+  const smtpPort = env.SMTP_PORT || '587';
+  const scheme = env.SMTP_SECURE === 'true' ? 'smtps' : 'smtp';
+  const auth = env.SMTP_USER
+    ? encodeURIComponent(env.SMTP_USER) + ':' + encodeURIComponent(env.SMTP_PASS || '') + '@'
+    : '';
+  return scheme + '://' + auth + smtpHost + ':' + smtpPort;
+}

--- a/meteor-backend/server/main.js
+++ b/meteor-backend/server/main.js
@@ -15,6 +15,7 @@ import { OAuth } from 'meteor/oauth';
 import { Random } from 'meteor/random';
 import { Accounts } from 'meteor/accounts-base';
 
+import { buildMailUrl } from './mail-url';
 import './collections';
 import './migration-login-handler';
 import { rawDb } from './collections';
@@ -630,14 +631,8 @@ WebApp.connectHandlers.use('/auth/apple/callback',
 // Build MAIL_URL from SMTP_* env vars so Meteor's `email` package (used by
 // Accounts.sendResetPasswordEmail) can send. Runs at module load.
 if (!process.env.MAIL_URL && process.env.SMTP_HOST) {
-  const smtpHost = process.env.SMTP_HOST;
-  const smtpPort = process.env.SMTP_PORT || '587';
-  const smtpUser = process.env.SMTP_USER;
-  const smtpPass = process.env.SMTP_PASS;
-  const scheme = process.env.SMTP_SECURE === 'true' ? 'smtps' : 'smtp';
-  const auth = smtpUser ? encodeURIComponent(smtpUser) + ':' + encodeURIComponent(smtpPass || '') + '@' : '';
-  process.env.MAIL_URL = scheme + '://' + auth + smtpHost + ':' + smtpPort;
-  console.log('[email] MAIL_URL configured: ' + scheme + '://' + smtpHost + ':' + smtpPort);
+  process.env.MAIL_URL = buildMailUrl(process.env);
+  console.log('[email] MAIL_URL configured: ' + process.env.MAIL_URL.replace(/\/\/[^@]+@/, '//***@'));
 }
 if (!process.env.ROOT_URL) {
   process.env.ROOT_URL = process.env.APP_URL || 'http://localhost:3000';

--- a/meteor-backend/tests/mail-url.test.ts
+++ b/meteor-backend/tests/mail-url.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Unit tests for buildMailUrl (server/mail-url.js).
+ *
+ * Regression coverage for the bug where SMTP_HOST="::1" (Mailpit's IPv6
+ * loopback, used to dodge a local port-1025 squatter — see
+ * ecosystem.config.cjs) produced an unbracketed "smtp://::1:1025" MAIL_URL.
+ * Node's `new URL()` (used internally by Meteor's `email` package) rejects
+ * that as ERR_INVALID_URL, which silently broke Accounts.sendResetPasswordEmail
+ * and surfaced to users as "Failed to send reset email. Please try again later."
+ */
+import { describe, it, expect } from 'vitest';
+import { buildMailUrl } from '../server/mail-url';
+
+describe('buildMailUrl', () => {
+  it('returns undefined when SMTP_HOST is not set', () => {
+    expect(buildMailUrl({})).toBeUndefined();
+  });
+
+  it('brackets an IPv6 loopback host (the Mailpit regression case)', () => {
+    expect(buildMailUrl({ SMTP_HOST: '::1', SMTP_PORT: '1025' })).toBe('smtp://[::1]:1025');
+  });
+
+  it('brackets a full IPv6 address', () => {
+    expect(buildMailUrl({ SMTP_HOST: '2001:db8::1', SMTP_PORT: '587' })).toBe(
+      'smtp://[2001:db8::1]:587',
+    );
+  });
+
+  it('does not double-bracket an already-bracketed host', () => {
+    expect(buildMailUrl({ SMTP_HOST: '[::1]', SMTP_PORT: '1025' })).toBe('smtp://[::1]:1025');
+  });
+
+  it('leaves an IPv4 host untouched', () => {
+    expect(buildMailUrl({ SMTP_HOST: '127.0.0.1', SMTP_PORT: '1025' })).toBe(
+      'smtp://127.0.0.1:1025',
+    );
+  });
+
+  it('leaves a hostname untouched', () => {
+    expect(buildMailUrl({ SMTP_HOST: 'smtp.example.com', SMTP_PORT: '587' })).toBe(
+      'smtp://smtp.example.com:587',
+    );
+  });
+
+  it('defaults to port 587 when SMTP_PORT is not set', () => {
+    expect(buildMailUrl({ SMTP_HOST: 'smtp.example.com' })).toBe('smtp://smtp.example.com:587');
+  });
+
+  it('uses the smtps scheme when SMTP_SECURE is "true"', () => {
+    expect(buildMailUrl({ SMTP_HOST: 'smtp.example.com', SMTP_SECURE: 'true' })).toBe(
+      'smtps://smtp.example.com:587',
+    );
+  });
+
+  it('includes url-encoded credentials when SMTP_USER is set', () => {
+    expect(
+      buildMailUrl({ SMTP_HOST: 'smtp.example.com', SMTP_USER: 'a b', SMTP_PASS: 'p@ss' }),
+    ).toBe('smtp://a%20b:p%40ss@smtp.example.com:587');
+  });
+
+  it('omits the password segment when SMTP_USER is set without SMTP_PASS', () => {
+    expect(buildMailUrl({ SMTP_HOST: 'smtp.example.com', SMTP_USER: 'user' })).toBe(
+      'smtp://user:@smtp.example.com:587',
+    );
+  });
+
+  it('produces a MAIL_URL that new URL() can parse without throwing', () => {
+    const url = buildMailUrl({ SMTP_HOST: '::1', SMTP_PORT: '1025' })!;
+    expect(() => new URL(url)).not.toThrow();
+    // Node's URL.hostname keeps the brackets for IPv6 literals.
+    expect(new URL(url).hostname).toBe('[::1]');
+    expect(new URL(url).port).toBe('1025');
+  });
+});

--- a/tests/e2e/auth/password-reset.spec.ts
+++ b/tests/e2e/auth/password-reset.spec.ts
@@ -10,6 +10,12 @@
  *   4. Open the reset link, submit a new password
  *   5. Sign in with the new password and land in the app
  *
+ * This also guards against a past regression where SMTP_HOST="::1" (Mailpit's
+ * IPv6 loopback — see ecosystem.config.cjs) produced an unbracketed MAIL_URL
+ * ("smtp://::1:1025"), which Node's `new URL()` rejects. That silently broke
+ * Accounts.sendResetPasswordEmail; step 2 above would fail immediately if it
+ * regresses. See meteor-backend/server/mail-url.js + its unit tests.
+ *
  * Requirements to run locally:
  *   - Meteor backend up on :3100
  *   - Vite frontend up on :3000


### PR DESCRIPTION
## Summary

Closes #433.

Password reset was already fully implemented end-to-end (forgot-password form, Meteor `Accounts.sendResetPasswordEmail`/`resetPassword`, reset-confirm screen in `LoginForm.tsx`), but it was silently broken: requesting a reset email always failed with **"Failed to send reset email. Please try again later."**

## Root cause

`meteor-backend/server/main.js` builds `MAIL_URL` from `SMTP_*` env vars at boot. Locally, `SMTP_HOST` is set to `::1` (Mailpit's IPv6 loopback — see `ecosystem.config.cjs`, used because a local process sometimes squats on `127.0.0.1:1025`). This produced `smtp://::1:1025`, which is **not a valid URL** — IPv6 literals must be bracketed (`[::1]`). Node's `new URL()`, used internally by Meteor's `email` package, threw `ERR_INVALID_URL`, causing `Accounts.sendResetPasswordEmail` to throw and the failure to surface to end users.

## Changes

- Extracted the `MAIL_URL` builder into `meteor-backend/server/mail-url.js` as a pure, Meteor-free `buildMailUrl(env)` function so it can be unit tested in isolation (Meteor packages can't be imported outside the Meteor runtime).
- Bracket IPv6 host literals when building `MAIL_URL`.
- Added `meteor-backend/tests/mail-url.test.ts` — 11 unit tests covering IPv6 (bare + already-bracketed), IPv4, hostnames, default port, `smtps` scheme, and credential encoding.
- Documented the regression in `tests/e2e/auth/password-reset.spec.ts`'s header comment (no behavioral changes needed there — it already exercises the full request-reset → Mailpit → set-new-password → sign-in flow and would fail at step 2 if this regresses).

## Testing

- `npx vitest run tests/mail-url.test.ts` (meteor-backend) — 11/11 passed.
- `npx playwright test tests/e2e/auth/password-reset.spec.ts` — 2/2 passed (full flow against live Meteor + Mailpit).
- Manually verified end-to-end via a live browser session: signup → sign out → request reset → email received in Mailpit → follow link → set new password → sign in with new password → old password rejected.
- `npm run lint` and `npm run typecheck` clean.
