### PR TITLE
Make channels editable/deletable and add channel notification deep-links

### DIFF
--- a/meteor-backend/server/channels.js
+++ b/meteor-backend/server/channels.js
@@ -129,6 +129,98 @@ Meteor.methods({
     return { channel: toPublicChannel(doc) };
   },
 
+  async 'channels.update'({ channelId, teamId, name, description, members }) {
+    const identity = await requireIdentity(this);
+    const userId = identity.userId;
+    if (!isValidId(teamId) || !isValidId(channelId)) {
+      throw new Meteor.Error('bad-request', 'Invalid channelId or teamId');
+    }
+
+    const team = await Teams.findOneAsync(new Mongo.ObjectID(teamId));
+    if (!team) throw new Meteor.Error('not-found', 'Team not found');
+    const allTeamMembers = [...team.members, ...(team.admins || [])];
+    if (!allTeamMembers.includes(userId)) {
+      throw new Meteor.Error('forbidden', 'Not a team member');
+    }
+
+    const channel = await Channels.rawCollection().findOne({
+      _id: new ObjectId(channelId),
+      teamId,
+    });
+    if (!channel) throw new Meteor.Error('not-found', 'Channel not found');
+    if (channel.createdBy !== userId && !(team.admins || []).includes(userId)) {
+      throw new Meteor.Error('forbidden', 'Only the creator or a team admin can edit this channel');
+    }
+
+    const update = {};
+
+    if (typeof name === 'string') {
+      const cleanName = name.trim().toLowerCase().replace(/[^a-z0-9-_]/g, '-').slice(0, 50);
+      if (!cleanName) throw new Meteor.Error('bad-request', 'name is required');
+      if (channel.isDefault && cleanName !== 'general') {
+        throw new Meteor.Error('bad-request', 'The default channel cannot be renamed');
+      }
+      if (cleanName !== channel.name) {
+        const existing = await Channels.rawCollection().findOne({
+          teamId,
+          name: cleanName,
+          _id: { $ne: channel._id },
+        });
+        if (existing) throw new Meteor.Error('duplicate', 'Channel name already exists');
+      }
+      update.name = cleanName;
+    }
+
+    if (typeof description === 'string') {
+      update.description = description.trim();
+    }
+
+    if (Array.isArray(members)) {
+      const validIds = members.filter((id) => allTeamMembers.includes(id));
+      if (!validIds.includes(channel.createdBy)) validIds.push(channel.createdBy);
+      update.members = validIds;
+    }
+
+    if (Object.keys(update).length === 0) {
+      return { channel: toPublicChannel(channel) };
+    }
+
+    await Channels.rawCollection().updateOne({ _id: channel._id }, { $set: update });
+    const updated = await Channels.rawCollection().findOne({ _id: channel._id });
+    return { channel: toPublicChannel(updated) };
+  },
+
+  async 'channels.delete'({ channelId, teamId }) {
+    const identity = await requireIdentity(this);
+    const userId = identity.userId;
+    if (!isValidId(teamId) || !isValidId(channelId)) {
+      throw new Meteor.Error('bad-request', 'Invalid channelId or teamId');
+    }
+
+    const team = await Teams.findOneAsync(new Mongo.ObjectID(teamId));
+    if (!team) throw new Meteor.Error('not-found', 'Team not found');
+    const allTeamMembers = [...team.members, ...(team.admins || [])];
+    if (!allTeamMembers.includes(userId)) {
+      throw new Meteor.Error('forbidden', 'Not a team member');
+    }
+
+    const channel = await Channels.rawCollection().findOne({
+      _id: new ObjectId(channelId),
+      teamId,
+    });
+    if (!channel) throw new Meteor.Error('not-found', 'Channel not found');
+    if (channel.createdBy !== userId && !(team.admins || []).includes(userId)) {
+      throw new Meteor.Error('forbidden', 'Only the creator or a team admin can delete this channel');
+    }
+    if (channel.isDefault) {
+      throw new Meteor.Error('forbidden', 'Cannot delete the default channel');
+    }
+
+    await ChannelMessages.rawCollection().deleteMany({ channelId });
+    await Channels.rawCollection().deleteOne({ _id: channel._id });
+    return { success: true };
+  },
+
   async 'channels.getMessages'({ channelId, teamId, before, limit }) {
     const identity = await requireIdentity(this);
     const userId = identity.userId;
@@ -219,7 +311,13 @@ Meteor.methods({
         userId: recipientId,
         title: `${senderName} in #${channel.name}`,
         body: truncatedText,
-        data: { type: 'channel_message', teamId, channelId, senderName, url: '/app/messages' },
+        data: {
+          type: 'channel_message',
+          teamId,
+          channelId,
+          senderName,
+          url: `/app/messages?openTeam=${teamId}&openChannel=${channelId}`,
+        },
       }).catch((err) => console.error('[channel] notification failed:', err));
     }
 

--- a/meteor-backend/server/main.js
+++ b/meteor-backend/server/main.js
@@ -1391,6 +1391,33 @@ Meteor.startup(async() => {
     },
   });
 
+  Wormhole.expose('channels.update', {
+    description: 'Edit a channel (name, description, members) — creator or team admin only',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channelId: { type: 'string' },
+        teamId: { type: 'string' },
+        name: { type: 'string' },
+        description: { type: 'string' },
+        members: { type: 'array', items: { type: 'string' } },
+      },
+      required: ['channelId', 'teamId'],
+    },
+  });
+
+  Wormhole.expose('channels.delete', {
+    description: 'Delete a non-default channel and its messages — creator or team admin only',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        channelId: { type: 'string' },
+        teamId: { type: 'string' },
+      },
+      required: ['channelId', 'teamId'],
+    },
+  });
+
   // ── Messages (DMs) ────────────────────────────────────────────────────────
 
   Wormhole.expose('messages.getThread', {

--- a/meteor-backend/tests/channels.test.ts
+++ b/meteor-backend/tests/channels.test.ts
@@ -1,0 +1,230 @@
+/**
+ * Channels — wormhole REST integration tests.
+ *
+ * Fixture: OWNER (team admin), MEMBER (regular, not the channel creator),
+ * OUTSIDER (not in team). Covers create/update/delete permissions and the
+ * channel-message push notification deep-link URL.
+ */
+import { describe, it, expect, beforeAll, afterAll } from 'vitest';
+import { createUserAndGetJwt, wormhole, getDb, closeDb, purgeUser } from './helpers';
+
+const OWNER = { name: 'Channel Owner', email: 'wh-channel-owner@test.dev', password: 'Password1!' };
+const MEMBER = { name: 'Channel Member', email: 'wh-channel-member@test.dev', password: 'Password1!' };
+const OUTSIDER = {
+  name: 'Channel Outsider',
+  email: 'wh-channel-outsider@test.dev',
+  password: 'Password1!',
+};
+
+let ownerJwt: string;
+let memberJwt: string;
+let outsiderJwt: string;
+let memberId: string;
+let fixtureTeamId: string;
+
+beforeAll(async () => {
+  await Promise.all([
+    purgeUser(OWNER.email),
+    purgeUser(MEMBER.email),
+    purgeUser(OUTSIDER.email),
+  ]);
+  const [owner, member, outsider] = await Promise.all([
+    createUserAndGetJwt(OWNER),
+    createUserAndGetJwt(MEMBER),
+    createUserAndGetJwt(OUTSIDER),
+  ]);
+  ownerJwt = owner.jwt;
+  memberJwt = member.jwt;
+  outsiderJwt = outsider.jwt;
+
+  const db = await getDb();
+  memberId = String(
+    (await db.collection('users').findOne({ 'emails.address': MEMBER.email }))!._id,
+  );
+
+  const createRes = await wormhole<{ team: { id: string } }>(
+    'teams.create',
+    { name: 'Channel Fixture Team' },
+    ownerJwt,
+  );
+  fixtureTeamId = createRes.result.team.id;
+  await wormhole('teams.invite', { teamId: fixtureTeamId, email: MEMBER.email }, ownerJwt);
+}, 30000);
+
+afterAll(async () => {
+  await wormhole('teams.delete', { teamId: fixtureTeamId }, ownerJwt).catch(() => {});
+  await Promise.all([purgeUser(OWNER.email), purgeUser(MEMBER.email), purgeUser(OUTSIDER.email)]);
+  await closeDb();
+});
+
+// ─── channels.list auto-provisioning ──────────────────────────────────────────
+
+describe('channels.list', () => {
+  it('rejects a non-team-member', async () => {
+    const res = await wormhole('channels.list', { teamId: fixtureTeamId }, outsiderJwt);
+    expect(res.ok).toBe(false);
+  });
+
+  it('auto-provisions a default #general channel', async () => {
+    const res = await wormhole<{ channels: Array<{ id: string; name: string; isDefault: boolean }> }>(
+      'channels.list',
+      { teamId: fixtureTeamId },
+      ownerJwt,
+    );
+    expect(res.ok).toBe(true);
+    const general = res.result.channels.find((c) => c.isDefault);
+    expect(general).toBeDefined();
+    expect(general!.name).toBe('general');
+  });
+});
+
+// ─── channels.update ──────────────────────────────────────────────────────────
+
+describe('channels.update', () => {
+  let channelId: string;
+
+  beforeAll(async () => {
+    const res = await wormhole<{ channel: { id: string } }>(
+      'channels.create',
+      { teamId: fixtureTeamId, name: 'eng-original', description: 'orig desc' },
+      memberJwt,
+    );
+    channelId = res.result.channel.id;
+  });
+
+  it('lets the creator rename the channel and update its description', async () => {
+    const res = await wormhole<{ channel: { name: string; description?: string } }>(
+      'channels.update',
+      { channelId, teamId: fixtureTeamId, name: 'eng-renamed', description: 'new desc' },
+      memberJwt,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.result.channel.name).toBe('eng-renamed');
+    expect(res.result.channel.description).toBe('new desc');
+  });
+
+  it('lets a team admin (non-creator) edit the channel', async () => {
+    const res = await wormhole<{ channel: { description?: string } }>(
+      'channels.update',
+      { channelId, teamId: fixtureTeamId, description: 'admin edited' },
+      ownerJwt,
+    );
+    expect(res.ok).toBe(true);
+    expect(res.result.channel.description).toBe('admin edited');
+  });
+
+  it('rejects edits from a non-creator, non-admin team member', async () => {
+    const otherMember = await createUserAndGetJwt({
+      name: 'Other Member',
+      email: 'wh-channel-other-member@test.dev',
+      password: 'Password1!',
+    });
+    await wormhole(
+      'teams.invite',
+      { teamId: fixtureTeamId, email: 'wh-channel-other-member@test.dev' },
+      ownerJwt,
+    );
+    const res = await wormhole('channels.update', { channelId, teamId: fixtureTeamId, description: 'nope' }, otherMember.jwt);
+    expect(res.ok).toBe(false);
+    await purgeUser('wh-channel-other-member@test.dev');
+  });
+
+  it('rejects duplicate channel names within the same team', async () => {
+    await wormhole('channels.create', { teamId: fixtureTeamId, name: 'dup-target' }, ownerJwt);
+    const res = await wormhole(
+      'channels.update',
+      { channelId, teamId: fixtureTeamId, name: 'dup-target' },
+      memberJwt,
+    );
+    expect(res.ok).toBe(false);
+  });
+});
+
+// ─── channels.delete ──────────────────────────────────────────────────────────
+
+describe('channels.delete', () => {
+  it('refuses to delete the default channel', async () => {
+    const listRes = await wormhole<{ channels: Array<{ id: string; isDefault: boolean }> }>(
+      'channels.list',
+      { teamId: fixtureTeamId },
+      ownerJwt,
+    );
+    const general = listRes.result.channels.find((c) => c.isDefault)!;
+    const res = await wormhole('channels.delete', { channelId: general.id, teamId: fixtureTeamId }, ownerJwt);
+    expect(res.ok).toBe(false);
+  });
+
+  it('rejects delete from a non-creator, non-admin member', async () => {
+    const createRes = await wormhole<{ channel: { id: string } }>(
+      'channels.create',
+      { teamId: fixtureTeamId, name: 'to-be-protected' },
+      memberJwt,
+    );
+    const channelId = createRes.result.channel.id;
+
+    const outsiderInTeam = await createUserAndGetJwt({
+      name: 'Delete Denier',
+      email: 'wh-channel-delete-denier@test.dev',
+      password: 'Password1!',
+    });
+    await wormhole(
+      'teams.invite',
+      { teamId: fixtureTeamId, email: 'wh-channel-delete-denier@test.dev' },
+      ownerJwt,
+    );
+    const res = await wormhole(
+      'channels.delete',
+      { channelId, teamId: fixtureTeamId },
+      outsiderInTeam.jwt,
+    );
+    expect(res.ok).toBe(false);
+    await purgeUser('wh-channel-delete-denier@test.dev');
+  });
+
+  it('lets the creator hard-delete a channel and its messages', async () => {
+    const createRes = await wormhole<{ channel: { id: string } }>(
+      'channels.create',
+      { teamId: fixtureTeamId, name: 'to-delete' },
+      memberJwt,
+    );
+    const channelId = createRes.result.channel.id;
+    await wormhole('channels.sendMessage', { channelId, teamId: fixtureTeamId, text: 'hi' }, memberJwt);
+
+    const db = await getDb();
+    expect(await db.collection('channelmessages').countDocuments({ channelId })).toBe(1);
+
+    const res = await wormhole('channels.delete', { channelId, teamId: fixtureTeamId }, memberJwt);
+    expect(res.ok).toBe(true);
+
+    expect(await db.collection('channels').findOne({ _id: new (await import('mongodb')).ObjectId(channelId) })).toBeNull();
+    expect(await db.collection('channelmessages').countDocuments({ channelId })).toBe(0);
+  });
+});
+
+// ─── channels.sendMessage notification deep-link ─────────────────────────────
+
+describe('channels.sendMessage notification', () => {
+  it('builds a channel-specific deep-link URL with openTeam and openChannel', async () => {
+    const createRes = await wormhole<{ channel: { id: string } }>(
+      'channels.create',
+      { teamId: fixtureTeamId, name: 'notif-check' },
+      ownerJwt,
+    );
+    const channelId = createRes.result.channel.id;
+
+    await wormhole(
+      'channels.sendMessage',
+      { channelId, teamId: fixtureTeamId, text: 'ping' },
+      ownerJwt,
+    );
+
+    const db = await getDb();
+    const notif = await db.collection('notifications').findOne({
+      userId: memberId,
+      'data.type': 'channel_message',
+      'data.channelId': channelId,
+    });
+    expect(notif).toBeTruthy();
+    expect(notif!.data.url).toBe(`/app/messages?openTeam=${fixtureTeamId}&openChannel=${channelId}`);
+  });
+});

--- a/src/features/messages/MessagesPage.tsx
+++ b/src/features/messages/MessagesPage.tsx
@@ -12,6 +12,7 @@ import {
   faEnvelope,
   faHashtag,
   faPaperPlane,
+  faPen,
   faPlus,
 } from '@fortawesome/free-solid-svg-icons';
 import { FontAwesomeIcon } from '@fortawesome/react-fontawesome';
@@ -25,6 +26,7 @@ import {
   ModalBody,
   ModalFooter,
   ModalHeader,
+  ModalTitle,
   Spinner,
   Text,
 } from '@mieweb/ui';
@@ -116,6 +118,17 @@ export const MessagesPage: React.FC = () => {
   const [createChannelError, setCreateChannelError] = useState<string | null>(null);
   const [channelSendError, setChannelSendError] = useState<string | null>(null);
 
+  // Edit / delete channel modal
+  const [showEditChannel, setShowEditChannel] = useState(false);
+  const [editChannelName, setEditChannelName] = useState('');
+  const [editChannelDesc, setEditChannelDesc] = useState('');
+  const [editChannelMembers, setEditChannelMembers] = useState<string[]>([]);
+  const [editChannelLoading, setEditChannelLoading] = useState(false);
+  const [editChannelError, setEditChannelError] = useState<string | null>(null);
+  const [showDeleteChannelConfirm, setShowDeleteChannelConfirm] = useState(false);
+  const [deleteChannelLoading, setDeleteChannelLoading] = useState(false);
+  const [deleteChannelError, setDeleteChannelError] = useState<string | null>(null);
+
   // ── DM state ─────────────────────────────────────────────────────────────────
   const [selectedMemberId, setSelectedMemberId] = useState<string | null>(null);
   const [memberNames, setMemberNames] = useState<Record<string, string>>({});
@@ -137,17 +150,22 @@ export const MessagesPage: React.FC = () => {
 
   // ── Deep-link / pending thread handling ──────────────────────────────────────
   const pendingOpenPeerRef = useRef<string | null>(null);
+  const pendingOpenChannelRef = useRef<string | null>(null);
   const pendingDmIntentRef = useRef(false);
   useEffect(() => {
     if (typeof window === 'undefined') return;
     const q = new URLSearchParams(window.location.search);
     const openTeam = q.get('openTeam');
     const openPeer = q.get('openPeer');
-    if (!openTeam && !openPeer) return;
+    const openChannel = q.get('openChannel');
+    if (!openTeam && !openPeer && !openChannel) return;
     if (openTeam) setSelectedTeamId(openTeam);
     if (openPeer) {
       pendingOpenPeerRef.current = openPeer;
       pendingDmIntentRef.current = true;
+    }
+    if (openChannel) {
+      pendingOpenChannelRef.current = openChannel;
     }
     window.history.replaceState(null, '', '/app/messages');
   }, []);
@@ -248,6 +266,15 @@ export const MessagesPage: React.FC = () => {
       .getChannels(selectedTeamId)
       .then((cs) => {
         setChannels(cs);
+        const pendingChannel = pendingOpenChannelRef.current
+          ? cs.find((c) => c.id === pendingOpenChannelRef.current)
+          : undefined;
+        if (pendingChannel) {
+          pendingOpenChannelRef.current = null;
+          setSelectedChannelId(pendingChannel.id);
+          setActiveView('channel');
+          return;
+        }
         const def = cs.find((c) => c.isDefault) ?? cs[0];
         if (def) {
           setSelectedChannelId(def.id);
@@ -433,6 +460,62 @@ export const MessagesPage: React.FC = () => {
     }
   }, [newChannelName, newChannelDesc, newChannelMembers, selectedTeamId]);
 
+  const selectedChannel = channels.find((c) => c.id === selectedChannelId);
+
+  // ── Edit / delete channel ─────────────────────────────────────────────────────
+  const canManageSelectedChannel =
+    !!selectedChannel && (selectedChannel.createdBy === userId || isAdmin);
+
+  const openEditChannel = useCallback(() => {
+    if (!selectedChannel) return;
+    setEditChannelName(selectedChannel.name);
+    setEditChannelDesc(selectedChannel.description ?? '');
+    setEditChannelMembers(selectedChannel.members ?? []);
+    setEditChannelError(null);
+    setShowEditChannel(true);
+  }, [selectedChannel]);
+
+  const handleUpdateChannel = useCallback(async () => {
+    if (!selectedChannelId || !selectedTeamId || !editChannelName.trim()) return;
+    setEditChannelLoading(true);
+    setEditChannelError(null);
+    try {
+      const updated = await channelApi.updateChannel(selectedChannelId, {
+        teamId: selectedTeamId,
+        name: editChannelName.trim(),
+        description: editChannelDesc.trim(),
+        members: editChannelMembers,
+      });
+      setChannels((prev) => prev.map((c) => (c.id === updated.id ? updated : c)));
+      setShowEditChannel(false);
+    } catch (err) {
+      setEditChannelError(err instanceof Error ? err.message : 'Failed to update channel');
+    } finally {
+      setEditChannelLoading(false);
+    }
+  }, [selectedChannelId, selectedTeamId, editChannelName, editChannelDesc, editChannelMembers]);
+
+  const handleDeleteChannel = useCallback(async () => {
+    if (!selectedChannelId || !selectedTeamId) return;
+    setDeleteChannelLoading(true);
+    setDeleteChannelError(null);
+    try {
+      await channelApi.deleteChannel(selectedChannelId, selectedTeamId);
+      setChannels((prev) => {
+        const remaining = prev.filter((c) => c.id !== selectedChannelId);
+        const fallback = remaining.find((c) => c.isDefault) ?? remaining[0] ?? null;
+        setSelectedChannelId(fallback ? fallback.id : null);
+        return remaining;
+      });
+      setShowDeleteChannelConfirm(false);
+      setShowEditChannel(false);
+    } catch (err) {
+      setDeleteChannelError(err instanceof Error ? err.message : 'Failed to delete channel');
+    } finally {
+      setDeleteChannelLoading(false);
+    }
+  }, [selectedChannelId, selectedTeamId]);
+
   // ── DM thread logic (load messages on select) ───────────────────────────────
   useEffect(() => {
     if (!selectedTeamId || !effectiveAdminId || !effectiveMemberId) {
@@ -615,8 +698,6 @@ export const MessagesPage: React.FC = () => {
     );
   }
 
-  const selectedChannel = channels.find((c) => c.id === selectedChannelId);
-
   return (
     <>
       <AppPage width="wide" fill>
@@ -781,6 +862,16 @@ export const MessagesPage: React.FC = () => {
                     <Text size="xs" variant="muted" className="ml-2 hidden md:block">
                       {selectedChannel.description}
                     </Text>
+                  )}
+                  {canManageSelectedChannel && (
+                    <button
+                      type="button"
+                      onClick={openEditChannel}
+                      className="ml-auto flex items-center justify-center rounded-lg p-1.5 text-neutral-400 hover:bg-neutral-100 hover:text-neutral-600 dark:hover:bg-neutral-800 dark:hover:text-neutral-300"
+                      aria-label={`Edit channel ${selectedChannel.name}`}
+                    >
+                      <FontAwesomeIcon icon={faPen} className="text-xs" />
+                    </button>
                   )}
                 </CardHeader>
 
@@ -1001,7 +1092,9 @@ export const MessagesPage: React.FC = () => {
         }}
         aria-label="Create channel"
       >
-        <ModalHeader>Create Channel</ModalHeader>
+        <ModalHeader>
+          <ModalTitle>Create Channel</ModalTitle>
+        </ModalHeader>
         <ModalBody>
           <div className="flex flex-col gap-4">
             {createChannelError && (
@@ -1083,6 +1176,153 @@ export const MessagesPage: React.FC = () => {
             isLoading={createChannelLoading}
           >
             Create
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Edit channel modal */}
+      <Modal
+        open={showEditChannel}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShowEditChannel(false);
+            setEditChannelError(null);
+          }
+        }}
+        aria-label="Edit channel"
+      >
+        <ModalHeader>
+          <ModalTitle>Edit Channel</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          <div className="flex flex-col gap-4">
+            {editChannelError && (
+              <p className="rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+                {editChannelError}
+              </p>
+            )}
+            <Input
+              label="Channel name"
+              size="sm"
+              disabled={!!selectedChannel?.isDefault}
+              placeholder="e.g. engineering"
+              value={editChannelName}
+              onChange={(e) => {
+                setEditChannelName(e.target.value);
+                setEditChannelError(null);
+              }}
+              onKeyDown={(e) => e.key === 'Enter' && handleUpdateChannel()}
+            />
+            {selectedChannel?.isDefault && (
+              <Text size="xs" variant="muted">
+                The default channel cannot be renamed.
+              </Text>
+            )}
+            <Input
+              label="Description (optional)"
+              size="sm"
+              placeholder="What is this channel for?"
+              value={editChannelDesc}
+              onChange={(e) => setEditChannelDesc(e.target.value)}
+            />
+            {memberNamesLoaded && threadMembers.length > 0 && (
+              <div>
+                <Text size="sm" weight="semibold" className="mb-2 block">
+                  Members
+                </Text>
+                <Text size="xs" variant="muted" className="mb-3 block">
+                  Leave all unchecked for a team-wide channel.
+                </Text>
+                <ul className="scrollbar-mieweb scrollbar-mieweb-visible max-h-48 rounded-lg border border-neutral-200 dark:border-neutral-700">
+                  {threadMembers.map((m) => (
+                    <li key={m.id}>
+                      <label className="flex cursor-pointer items-center gap-3 px-3 py-2.5 hover:bg-neutral-50 dark:hover:bg-neutral-800">
+                        <input
+                          type="checkbox"
+                          className="h-4 w-4 rounded border-neutral-300 accent-blue-600"
+                          checked={editChannelMembers.includes(m.id)}
+                          onChange={(e) =>
+                            setEditChannelMembers((prev) =>
+                              e.target.checked ? [...prev, m.id] : prev.filter((id) => id !== m.id),
+                            )
+                          }
+                        />
+                        <UserAvatar name={m.name} size="sm" src={memberImages[m.id]} />
+                        <span className="text-sm">{m.name}</span>
+                      </label>
+                    </li>
+                  ))}
+                </ul>
+                {editChannelMembers.length > 0 && (
+                  <Text size="xs" variant="muted" className="mt-1">
+                    {editChannelMembers.length} member{editChannelMembers.length > 1 ? 's' : ''}{' '}
+                    selected
+                  </Text>
+                )}
+              </div>
+            )}
+          </div>
+        </ModalBody>
+        <ModalFooter>
+          {!selectedChannel?.isDefault && (
+            <Button
+              variant="danger"
+              className="mr-auto"
+              onClick={() => setShowDeleteChannelConfirm(true)}
+            >
+              Delete channel
+            </Button>
+          )}
+          <Button variant="ghost" onClick={() => setShowEditChannel(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="primary"
+            onClick={handleUpdateChannel}
+            disabled={editChannelLoading || !editChannelName.trim()}
+            isLoading={editChannelLoading}
+          >
+            Save
+          </Button>
+        </ModalFooter>
+      </Modal>
+
+      {/* Delete channel confirmation */}
+      <Modal
+        open={showDeleteChannelConfirm}
+        onOpenChange={(open) => {
+          if (!open) {
+            setShowDeleteChannelConfirm(false);
+            setDeleteChannelError(null);
+          }
+        }}
+        size="sm"
+        aria-label="Delete channel"
+      >
+        <ModalHeader>
+          <ModalTitle>Delete #{selectedChannel?.name}?</ModalTitle>
+        </ModalHeader>
+        <ModalBody>
+          {deleteChannelError && (
+            <p className="mb-2 rounded-md bg-red-50 px-3 py-2 text-sm text-red-600 dark:bg-red-950 dark:text-red-400">
+              {deleteChannelError}
+            </p>
+          )}
+          <Text variant="muted" size="sm">
+            This will permanently delete this channel and all of its messages.
+          </Text>
+        </ModalBody>
+        <ModalFooter>
+          <Button variant="ghost" onClick={() => setShowDeleteChannelConfirm(false)}>
+            Cancel
+          </Button>
+          <Button
+            variant="danger"
+            onClick={handleDeleteChannel}
+            disabled={deleteChannelLoading}
+            isLoading={deleteChannelLoading}
+          >
+            Delete
           </Button>
         </ModalFooter>
       </Modal>

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1754,6 +1754,18 @@ export const channelApi = {
       channelId,
       ...data,
     }).then((r) => r.message),
+
+  updateChannel: (
+    channelId: string,
+    data: { teamId: string; name?: string; description?: string; members?: string[] },
+  ): Promise<Channel> =>
+    wormholeCall<{ channel: Channel }>('channels.update', {
+      channelId,
+      ...data,
+    }).then((r) => r.channel),
+
+  deleteChannel: (channelId: string, teamId: string): Promise<void> =>
+    wormholeCall<{ success: boolean }>('channels.delete', { channelId, teamId }).then(() => {}),
 };
 
 // ─── Personal Access Tokens ───────────────────────────────────────────────────

--- a/tests/e2e/messages/channels.spec.ts
+++ b/tests/e2e/messages/channels.spec.ts
@@ -1,0 +1,187 @@
+/**
+ * Channels E2E Tests
+ *
+ * 1. Create, edit, and delete a channel from the Messages page
+ * 2. The default #general channel cannot be deleted
+ * 3. A channel message notifies other team members and the notification
+ *    deep-links to the exact channel on click
+ */
+import { test, expect, type Page } from '@playwright/test';
+import { MongoClient } from 'mongodb';
+import { TEST_USERS, loginAs } from '../fixtures/users';
+
+const MONGO_URL =
+  process.env.MONGO_URL ?? 'mongodb://127.0.0.1:27017/timehuddle_test?replicaSet=rs0';
+
+async function getTeamId(code: string): Promise<string | null> {
+  const client = await MongoClient.connect(MONGO_URL);
+  const db = client.db();
+  const team = await db.collection('teams').findOne({ code });
+  await client.close();
+  return team ? String(team._id) : null;
+}
+
+/** Remove any e2e-created channels (and their messages) for the test team. */
+async function cleanupTestChannels(teamId: string): Promise<void> {
+  const client = await MongoClient.connect(MONGO_URL);
+  const db = client.db();
+  const testChannels = await db
+    .collection('channels')
+    .find({ teamId, name: { $regex: /^e2e-/i } })
+    .toArray();
+  const channelIds = testChannels.map((c) => String(c._id));
+  if (channelIds.length > 0) {
+    await db.collection('channelmessages').deleteMany({ channelId: { $in: channelIds } });
+    await db.collection('channels').deleteMany({ _id: { $in: testChannels.map((c) => c._id) } });
+  }
+  await client.close();
+}
+
+/** Select the Test Team Alpha on the Messages page via localStorage + reload. */
+async function selectTestTeam(page: Page): Promise<string | null> {
+  const teamId = await getTeamId('TEST01');
+  if (!teamId) return null;
+
+  await page.evaluate((id) => {
+    Object.keys(localStorage)
+      .filter((k) => k.startsWith('app:selectedTeamId'))
+      .forEach((k) => localStorage.setItem(k, id));
+    localStorage.setItem('app:selectedTeamId', id);
+  }, teamId);
+  await page.reload();
+  await page.getByRole('heading', { level: 1, name: 'Messages' }).waitFor({ state: 'visible' });
+  await page.waitForLoadState('networkidle');
+  return teamId;
+}
+
+async function createChannel(page: Page, name: string): Promise<void> {
+  await page.getByRole('button', { name: 'Create channel' }).click();
+  await page.getByLabel('Channel name').fill(name);
+  await page.getByRole('button', { name: 'Create', exact: true }).click();
+  await expect(page.getByPlaceholder(`Message #${name}`)).toBeVisible({ timeout: 10000 });
+}
+
+let fixtureTeamId: string | null = null;
+
+test.describe('Channels — create, edit, delete', () => {
+  test.beforeEach(async ({ page }) => {
+    await loginAs(page, TEST_USERS.owner1);
+    await page.goto('/app/messages');
+    await page.getByRole('heading', { level: 1, name: 'Messages' }).waitFor({ state: 'visible' });
+    fixtureTeamId = await selectTestTeam(page);
+    test.skip(!fixtureTeamId, 'Test Team Alpha (TEST01) not found in DB');
+  });
+
+  test.afterEach(async () => {
+    if (fixtureTeamId) await cleanupTestChannels(fixtureTeamId);
+  });
+
+  test('creates a new channel and selects it', async ({ page }) => {
+    const channelName = `e2e-create-${Date.now()}`;
+    await createChannel(page, channelName);
+
+    await expect(
+      page.getByRole('button', { name: `Channel ${channelName}`, exact: true }),
+    ).toBeVisible();
+    await expect(page.getByPlaceholder(`Message #${channelName}`)).toBeVisible();
+  });
+
+  test('edits a channel name and description', async ({ page }) => {
+    const channelName = `e2e-edit-${Date.now()}`;
+    await createChannel(page, channelName);
+
+    const renamed = `${channelName}-renamed`;
+    await page.getByRole('button', { name: `Edit channel ${channelName}` }).click();
+    await page.getByRole('heading', { name: 'Edit Channel' }).waitFor({ state: 'visible' });
+    await page.getByLabel('Channel name').fill(renamed);
+    await page.getByLabel('Description (optional)').fill('Updated by e2e test');
+    await page.getByRole('button', { name: 'Save' }).click();
+
+    await expect(page.getByPlaceholder(`Message #${renamed}`)).toBeVisible({ timeout: 10000 });
+    await expect(page.getByText('Updated by e2e test')).toBeVisible();
+  });
+
+  test('deletes a non-default channel', async ({ page }) => {
+    const channelName = `e2e-delete-${Date.now()}`;
+    await createChannel(page, channelName);
+
+    await page.getByRole('button', { name: `Edit channel ${channelName}` }).click();
+    await page.getByRole('button', { name: 'Delete channel' }).click();
+    await page.getByRole('heading', { name: `Delete #${channelName}?` }).waitFor({
+      state: 'visible',
+    });
+    await page.getByRole('button', { name: 'Delete', exact: true }).click();
+
+    await expect(page.getByRole('button', { name: `Channel ${channelName}` })).toHaveCount(0, {
+      timeout: 10000,
+    });
+    // Falls back to the default channel.
+    await expect(page.getByPlaceholder('Message #general')).toBeVisible();
+  });
+
+  test('does not allow deleting the default #general channel', async ({ page }) => {
+    await page.getByRole('button', { name: 'Channel general', exact: true }).click();
+    await page.getByRole('button', { name: 'Edit channel general' }).click();
+    await page.getByRole('heading', { name: 'Edit Channel' }).waitFor({ state: 'visible' });
+
+    await expect(page.getByRole('button', { name: 'Delete channel' })).toHaveCount(0);
+    await expect(page.getByText('The default channel cannot be renamed.')).toBeVisible();
+  });
+});
+
+test.describe('Channel message notifications', () => {
+  test('notifies other team members and deep-links to the exact channel on click', async ({
+    browser,
+  }) => {
+    const teamId = await getTeamId('TEST01');
+    test.skip(!teamId, 'Test Team Alpha (TEST01) not found in DB');
+
+    const adminContext = await browser.newContext();
+    const memberContext = await browser.newContext();
+    const adminPage = await adminContext.newPage();
+    const memberPage = await memberContext.newPage();
+
+    try {
+      await loginAs(adminPage, TEST_USERS.owner1);
+      await adminPage.goto('/app/messages');
+      await adminPage
+        .getByRole('heading', { level: 1, name: 'Messages' })
+        .waitFor({ state: 'visible' });
+      await selectTestTeam(adminPage);
+
+      const channelName = `e2e-notif-${Date.now()}`;
+      await createChannel(adminPage, channelName);
+
+      const messageText = `Hello team, e2e ping ${Date.now()}`;
+      await adminPage.getByPlaceholder(`Message #${channelName}`).fill(messageText);
+      await adminPage.getByRole('button', { name: 'Send message' }).click();
+      await expect(adminPage.getByText(messageText)).toBeVisible();
+
+      // Member checks the Notifications inbox for the channel-message notification.
+      await loginAs(memberPage, TEST_USERS.member1);
+      await memberPage.goto('/app/notifications');
+      await memberPage
+        .getByRole('heading', { level: 1, name: /Notifications/i })
+        .waitFor({ state: 'visible' });
+
+      const notifRow = memberPage
+        .getByRole('button')
+        .filter({ hasText: `#${channelName}` })
+        .first();
+      await expect(notifRow).toBeVisible({ timeout: 15000 });
+      await notifRow.click();
+
+      // Clicking the notification should land on Messages with the exact
+      // channel selected (openTeam/openChannel deep-link), not just the default.
+      await expect(memberPage).toHaveURL(/\/app\/messages/, { timeout: 10000 });
+      await expect(memberPage.getByPlaceholder(`Message #${channelName}`)).toBeVisible({
+        timeout: 10000,
+      });
+
+      if (teamId) await cleanupTestChannels(teamId);
+    } finally {
+      await adminContext.close();
+      await memberContext.close();
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Closes #432 by hardening the Messages feature so it can fully replace SMS-based updates: channels are now editable and deletable, not just creatable.
- Adds `channels.update` and `channels.delete` Meteor methods (creator-or-team-admin only; the default `#general` channel can't be renamed away from "general" or deleted).
- Fixes channel-message push notifications to carry a specific `openTeam`/`openChannel` deep-link (previously a generic `/app/messages` URL), so clicking a notification opens the exact channel — mirroring the existing DM thread deep-link behavior.
- Adds an edit/delete UI (pencil icon + modal) to `MessagesPage.tsx`, gated to the channel creator or a team admin.

## Test plan
- [x] `meteor-backend/tests/channels.test.ts` (new, 10 cases) — permission checks for edit/delete, duplicate-name rejection, default-channel protection, cascading delete of channel messages, and the notification deep-link URL shape. Full backend suite passes (123/123).
- [x] `tests/e2e/messages/channels.spec.ts` (new, 5 cases) — create/edit/delete channel UI flows, default-channel delete protection, and an end-to-end notification-click deep-link test across two sessions. All passing.
- [x] `npm run typecheck && npm run lint && npm run format` — clean.