### PR TITLE
Fix bcrypt bundling, proxy JWT imports, a false "No team available" on Tickets, and pin pulsevault to the registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -53,6 +53,11 @@ meteor-backend/.meteor/local-test/
 backend/nginx-apple-proxy.conf
 meteor-backend/start-rosetta.sh
 
+# Local working clone of github.com/mieweb/ui — has its own .git, so committing
+# it would record a gitlink with no matching .gitmodules entry. @mieweb/ui is
+# consumed from npm; nothing in this project reads vendor/ui.
+vendor/ui/
+
 # Database backups (migration and production backups)
 backups/
 prod-backups/

--- a/meteor-backend/.meteor/.gitignore
+++ b/meteor-backend/.meteor/.gitignore
@@ -1,1 +1,2 @@
 local
+local-test

--- a/meteor-backend/package-lock.json
+++ b/meteor-backend/package-lock.json
@@ -9,7 +9,7 @@
         "@agendajs/mongo-backend": "^4.0.2",
         "@babel/runtime": "^7.23.5",
         "@casl/ability": "^6.8.1",
-        "@mieweb/pulsevault": "github:mieweb/pulsevault",
+        "@mieweb/pulsevault": "^0.1.1",
         "@parse/node-apn": "^8.1.0",
         "@swc/helpers": "^0.5.17",
         "agenda": "^6.2.5",
@@ -1205,8 +1205,9 @@
       }
     },
     "node_modules/@mieweb/pulsevault": {
-      "version": "0.1.0",
-      "resolved": "git+ssh://git@github.com/mieweb/pulsevault.git#f41f55790083a6f3c4c50c85d1b640ddace5620a",
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/@mieweb/pulsevault/-/pulsevault-0.1.1.tgz",
+      "integrity": "sha512-yCLSNKwYx6QfW+aMNtvvvTt+4+PGxTTg2zBiHzPWSJu8mEXmMGqjf0QuPLlfG1wKSMv1tDAoaxw5I0jrfY9AoA==",
       "license": "MIT",
       "dependencies": {
         "@fastify/send": "^4.1.0",

--- a/meteor-backend/package.json
+++ b/meteor-backend/package.json
@@ -12,7 +12,7 @@
     "@agendajs/mongo-backend": "^4.0.2",
     "@babel/runtime": "^7.23.5",
     "@casl/ability": "^6.8.1",
-    "@mieweb/pulsevault": "github:mieweb/pulsevault",
+    "@mieweb/pulsevault": "^0.1.1",
     "@parse/node-apn": "^8.1.0",
     "@swc/helpers": "^0.5.17",
     "agenda": "^6.2.5",

--- a/meteor-backend/server/auth-bridge.js
+++ b/meteor-backend/server/auth-bridge.js
@@ -14,6 +14,10 @@ import { Meteor } from 'meteor/meteor';
 import { Accounts } from 'meteor/accounts-base';
 import { MongoInternals } from 'meteor/mongo';
 import { createHash } from 'crypto';
+// Static import (not Npm.require) so Meteor's bundler links the app's bcrypt
+// into the server bundle. Npm.require is a runtime lookup that happens after
+// bundling, so it cannot pull a package the bundler never included.
+import bcrypt from 'bcrypt';
 import { currentBearerToken } from 'meteor/wreiske:meteor-wormhole';
 import { rawDb } from './collections';
 
@@ -164,7 +168,6 @@ async function resolvePat(token) {
 }
 
 async function resolveMeteorToken(token) {
-  const { createHash } = Npm.require('crypto');
   const hashedToken = createHash('sha256').update(token).digest('base64');
   
   const user = await Meteor.users.findOneAsync({
@@ -283,6 +286,7 @@ async function verifyProxyJwt(token) {
   const secret = getProxySecret();
   if (!secret) return null;
   try {
+    const { jwtVerify } = await import('jose');
     const { payload } = await jwtVerify(token, secret);
     if (!payload.proxy || !payload.email) return null;
     return { email: payload.email, name: payload.name };
@@ -295,6 +299,7 @@ async function verifyProxyJwt(token) {
 export async function signProxyJwt(email, name) {
   const secret = getProxySecret();
   if (!secret) throw new Error('PROXY_JWT_SECRET not set');
+  const { SignJWT } = await import('jose');
   return new SignJWT({ email, name, proxy: true })
     .setProtectedHeader({ alg: 'HS256' })
     .setIssuedAt()
@@ -517,7 +522,6 @@ Accounts.registerLoginHandler('emailPassword', async (options) => {
   // crypto.subtle is undefined).
   const storedBcrypt = user?.services?.password?.bcrypt;
   if (storedBcrypt) {
-    const bcrypt = Npm.require('bcrypt');
     const clientDigest = password.digest && password.digest.length > 0
       ? password.digest
       : createHash('sha256').update(password.raw).digest('hex');

--- a/src/features/tickets/TicketsPage.tsx
+++ b/src/features/tickets/TicketsPage.tsx
@@ -1026,6 +1026,10 @@ export const TicketsPage: React.FC = () => {
               variant="primary"
               size="sm"
               leftIcon={<FontAwesomeIcon icon={faPlus} />}
+              // Teams arrive asynchronously, so selectedTeam is null on first
+              // paint even for users who have one. Without this guard an early
+              // click reports "No team available" to a user who has a team.
+              disabled={!teamsReady}
               onClick={() => {
                 if (!selectedTeam) {
                   setShowNoTeamDialog(true);


### PR DESCRIPTION
## Overview

Four independent bugs found while stabilising the e2e suite. All were latent on `main`. Full suite is green: **123/123 passed**, typecheck clean, lint 0 errors, prettier clean.

## Changes

### `fix(auth)` — `meteor-backend/server/auth-bridge.js`

**Proxy JWT was broken.** `jwtVerify` and `SignJWT` were used in `verifyProxyJwt()` / `signProxyJwt()` but never imported anywhere in the file. Once `PROXY_JWT_SECRET` is set:
- `verifyProxyJwt` swallowed the `ReferenceError` in its bare `catch`, so Authentik proxy login failed **silently** — indistinguishable from an invalid token.
- `signProxyJwt` had no catch and threw outright at `/auth/whoami`.

Both now `await import('jose')` at the call site, which also avoids the ESM named-import crash documented in CLAUDE.md for Node 24.

**bcrypt was pulled in via `Npm.require`.** That's a *runtime* lookup that happens after bundling, so it cannot pull a package Meteor's bundler never included. Replaced with a static `import`, which puts it in the module graph — the rebuilt bundle now resolves the app's bcrypt 6.0.0.

Also removed a redundant `Npm.require('crypto')` that shadowed the top-level `createHash` import.

> Note: `accounts-password@3.2.3` ships its own bcrypt 5.0.1 inside the Meteor package store, separate from the app's 6.0.0. That is normal isopack isolation, not a conflict — both produce interoperable `$2b$` hashes and both load correctly under Meteor's x64 Node.

### `fix(tickets)` — `src/features/tickets/TicketsPage.tsx`

Teams load asynchronously, so `selectedTeam` is `null` on first paint even for users who have one. Clicking **New Ticket** in that window opened the **"No team available"** dialog for a user whose team was already visible in the header — confirmed from a Playwright failure snapshot showing both at once.

Gated the button on the existing `teamsReady` flag (already destructured in the component, previously unused for this). Also lets Playwright's enabled-state auto-wait settle the timing, so no test files needed editing: the mobile/tablet dropdown specs went from **1/3 to 6/6** on repeat runs.

### `chore(deps)` — `@mieweb/pulsevault` → registry 0.1.1

The lockfile pinned a `git+ssh` ref at version **0.1.0** while **0.1.1** was what actually sat in `node_modules`. Two problems: `npm ci` was not reproducible, and it required an SSH key with repo access even though the package is published publicly on npm — which breaks CI and fresh clones.

Now resolved from the registry. `package.json`, the lockfile and the install ledger all agree on 0.1.1 with an integrity hash, and **no `git+ssh` entries remain** in the lockfile.

0.1.1 is 7 commits ahead of the pinned `f41f5579` and carries fixes on the TUS upload path this app uses for ticket video and media-library uploads:
- process-crash fix when an upload connection aborts mid-PATCH (#50)
- matching hardening for POST creation-with-upload
- polynomial-regex (ReDoS) fix in TUS URL segment extraction (#52)

### `chore` — ignore rules

- `vendor/ui/` — a local working clone of `github.com/mieweb/ui` with its own `.git`. Committing it would record a gitlink with no matching `.gitmodules` entry. `@mieweb/ui` is consumed from npm; nothing in this project reads `vendor/ui`.
- `meteor-backend/.meteor/local-test` — build dir for the isolated test Meteor instance (see below).

## Not in this PR

**The `.meteor/local` race.** `ecosystem.config.cjs` ran both `timehuddle-meteor` and `timehuddle-meteor-test` from the same cwd, so both built into and executed from one `.meteor/local` — a rebuild from one tears down the `npm/node_modules` symlink farm the other is executing from, which surfaces as intermittent "cannot find module" failures. Fixed locally with `METEOR_LOCAL_DIR: '.meteor/local-test'` on the test instance; pm2 restart counts went from ↺49/↺28 to **↺0/↺0** across a full suite run.

That file is gitignored (machine-specific paths), so the fix can't travel in this PR. Anyone reproducing the two-instance setup needs the same env var.

## Follow-up (not addressed)

`bcryptjs@^3.0.3` is declared in `meteor-backend/package.json` but imported nowhere.

## Test plan

- [x] `npm run test` — 123/123 passed, re-run after the pulsevault bump (6.8m)
- [x] All 13 PulseVault + media-upload e2e specs green on 0.1.1
- [x] `npm run typecheck` — clean
- [x] `eslint` on changed files — 0 errors
- [x] `prettier --check` — clean
- [x] Mobile/tablet dropdown specs — 6/6 across repeats (was 1/3)
- [ ] Proxy JWT path is **not** covered by e2e (`PROXY_JWT_SECRET` is unset in test env, so both functions bail at the secret guard). Worth manual verification against an Authentik setup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)