### PR TITLE
fix(docs): align support contact email across privacy/support docs

### DIFF
--- a/docs/support.html
+++ b/docs/support.html
@@ -596,7 +596,7 @@
             <div class="contact-icon">📧</div>
             <h3>Email Support</h3>
             <p>
-              <a href="mailto:dharamkarpoonam9@gmail.com">dharamkarpoonam9@gmail.com</a>
+              <a href="mailto:support@mieweb.com">support@mieweb.com</a>
             </p>
             <p style="margin-top: 8px; font-size: 14px; color: var(--text-secondary)">
               We typically respond within 24-48 hours


### PR DESCRIPTION
Fixes App Store rejection 1.5.0 Safety: Developer Information / 5.1.1 Legal: Privacy — docs/support.html listed a different personal email (dharamkarpoonam9@gmail.com) than PRIVACY_POLICY.md and privacy.html (support@mieweb.com). Now all three are consistent.