### PR TITLE
Fix Editor Text Colour, Font and Height After Kerebron 0.8.9 Upgrade

### DIFF
--- a/src/features/huddle/MarkdownEditor.tsx
+++ b/src/features/huddle/MarkdownEditor.tsx
@@ -52,8 +52,6 @@ export function MarkdownEditor({
     <div
       className={[
         'markdown-editor rounded-lg border border-gray-200 dark:border-neutral-700',
-        '[&_.ProseMirror]:min-h-52 [&_.ProseMirror]:px-3 [&_.ProseMirror]:py-2.5',
-        '[&_.ProseMirror]:text-base [&_.ProseMirror]:leading-relaxed [&_.ProseMirror]:outline-none',
         className ?? '',
       ].join(' ')}
       // Drives the `.ProseMirror::before` placeholder in styles.css. Floated

--- a/src/styles.css
+++ b/src/styles.css
@@ -41,6 +41,21 @@ html[data-theme='dark'] {
   color-scheme: dark;
 }
 
+/* Kerebron 0.8.9 added `.kb-editor { all: initial }` to its base.css, which
+   resets the editable area's colour to black and font to serif. That sheet is
+   imported unlayered (top of this file), so it outranks Tailwind's layered
+   utilities regardless of specificity — the fix has to be unlayered too. */
+.kb-component .kb-editor {
+  color: var(--kb-color-text);
+  font-family: inherit;
+}
+
+/* Same reset zeroes the editor's height, so `min-h-*` utilities on the wrapper
+   no longer reach it. Owned here rather than in MarkdownEditor's className. */
+.markdown-editor .kb-editor {
+  min-height: 13rem;
+}
+
 /* Kerebron RichEditor dark mode — the editor themes via `.kb-component--dark`
    or `prefers-color-scheme`, but the app drives theme with `data-theme`, so map
    its CSS variables here. Without this the editor stays light while the app is


### PR DESCRIPTION
## Overview

The `@kerebron/*` 0.8.6 → 0.8.9 bump (#459) made the rich-text editor unusable: text renders black in serif (invisible in dark mode) and the content box collapses from 208px to ~42px. Affects the Huddle composer and the Clock plan/wrap-up composer.

## Current State

- 0.8.9 added a reset to `@kerebron/editor/assets/base.css` that 0.8.6 did not have:
  ```css
  .kb-editor { all: initial; display: block; }
  .kb-editor, .kb-editor * { margin:0; padding:0; box-sizing:border-box; }
  ```
- `all: initial` resets `color` to black and `font-family` to serif, and zeroes the height.
- `src/styles.css` imports `@mieweb/ui/kerebron.css` **unlayered**, while `@import 'tailwindcss'` puts utilities in `@layer utilities`. Unlayered author styles win over layered ones regardless of specificity, so the `[&_.ProseMirror]:min-h-52` utilities on the wrapper never applied.

Measured on the running app before the fix: `color: rgb(0,0,0)`, `font-family: Times`, `min-height: auto`, height 42px.

## Proposed Changes

1. **`src/styles.css`** — restore the reset properties from unlayered rules so they can actually compete:
   - `.kb-component .kb-editor` → `color: var(--kb-color-text)`, `font-family: inherit`
   - `.markdown-editor .kb-editor` → `min-height: 13rem`
2. **`src/features/huddle/MarkdownEditor.tsx`** — drop the `[&_.ProseMirror]:*` arbitrary variants that can no longer apply, so height has a single source of truth.

Using the existing `--kb-color-text` variable keeps the fix theme-aware instead of hard-coding a colour. Padding, font-size and line-height are deliberately untouched — kerebron sets those itself and they are identical between 0.8.6 and 0.8.9.

## Acceptance Criteria

- [x] Editor text is readable in dark mode (`#e5e7eb`) and light mode (`#1f2937`)
- [x] Editor renders in the app sans-serif stack, not serif
- [x] Editor height back to 208px (`min-h-52`)
- [x] `npm run typecheck` passes
- [x] `npm run lint` passes
- [x] `npm run format` clean
- [x] `npm run test:unit` — 97/97

## Out of Scope (for Now)

- **Regression coverage.** No automated check would have caught this — typecheck, lint, unit tests and the build all passed while the editor was visually broken. A Playwright assertion on `.kb-editor` computed `color`/`min-height` would catch this class of vendor-CSS regression, but belongs in its own PR.
- **Moving kerebron's stylesheet into a cascade layer.** That would fix the root ordering problem generally, but shifts every kerebron rule relative to app utilities — too broad to bundle with a hotfix.