### PR TITLE
Extend Org Admin Authority to Team Management

### DIFF
--- a/meteor-backend/server/org-helpers.js
+++ b/meteor-backend/server/org-helpers.js
@@ -170,15 +170,19 @@ export async function getAccessibleOrgIds(userId) {
 
 /**
  * True if `userId` has team-admin authority on `team` — either because they
- * are listed in `team.admins`, or because they own the organization the team
- * belongs to. Org owners get full team-admin authority on every team in
- * their org (rename, delete, invite, remove member, set role/password,
- * approve/decline join requests, manage invitations).
+ * are listed in `team.admins`, or because they are an owner/admin of the
+ * organization the team belongs to. Org owners and admins get full team-admin
+ * authority on every team in their org (rename, delete, invite, remove member,
+ * set role/password, approve/decline join requests, manage invitations).
  */
 export async function isTeamAdminOrOrgOwner(team, userId) {
   if (team.admins.includes(userId)) return true;
   if (!team.orgId || !isValidId(team.orgId)) return false;
+  // Check modern org_members collection first (owner or admin both qualify)
+  const membership = await rawDb().collection('org_members').findOne({ orgId: team.orgId, userId });
+  if (membership?.role === 'owner' || membership?.role === 'admin') return true;
+  // Fallback to legacy owners/admins arrays on the org document
   const org = await rawDb().collection('organizations').findOne({ _id: new ObjectId(team.orgId) });
-  return !!org?.owners?.includes(userId);
+  return !!org?.owners?.includes(userId) || !!org?.admins?.includes(userId);
 }
 

--- a/meteor-backend/server/permissions.js
+++ b/meteor-backend/server/permissions.js
@@ -68,6 +68,10 @@ async function resolveOrgRoleForTeam(userId, team) {
   const membership = await rawDb().collection('org_members').findOne({ orgId: team.orgId, userId });
   if (membership?.role === 'owner') return 'owner';
   if (membership?.role === 'admin') return 'admin';
+  // Fallback to legacy owners/admins arrays for data predating org_members migration
+  const org = await rawDb().collection('organizations').findOne({ _id: new ObjectId(team.orgId) });
+  if ((org?.owners ?? []).includes(userId)) return 'owner';
+  if ((org?.admins ?? []).includes(userId)) return 'admin';
   return 'member';
 }
 
@@ -118,7 +122,8 @@ export async function buildTeamAbility(userId, teamId) {
     orgIds: team.orgId ? [team.orgId] : [],
     enterpriseIds: enterpriseScope.enterpriseId ? [enterpriseScope.enterpriseId] : [],
     isEnterpriseElevated: enterpriseScope.elevated,
-    teamAdminIds: (team.admins ?? []).includes(userId) ? [teamId] : [],
+    // Org owners/admins have team-admin authority on all teams in their org
+    teamAdminIds: (team.admins ?? []).includes(userId) || isOrgElevated ? [teamId] : [],
   });
 
   return { team, scoped, ability };

--- a/meteor-backend/server/teams.js
+++ b/meteor-backend/server/teams.js
@@ -110,26 +110,52 @@ function toPublicTeam(team) {
   };
 }
 
-Meteor.publish('teams.byUser', function () {
+Meteor.publish('teams.byUser', async function () {
   if (!this.userId) return this.ready();
   const userId = this.userId;
-  return Teams.find({ members: userId });
+  // Also surface all teams in orgs where this user is an owner or admin
+  const elevatedMemberships = await rawDb()
+    .collection('org_members')
+    .find({ userId, role: { $in: ['owner', 'admin'] } })
+    .toArray();
+  const elevatedOrgIds = elevatedMemberships.map((m) => m.orgId);
+  const filter =
+    elevatedOrgIds.length > 0
+      ? { $or: [{ members: userId }, { orgId: { $in: elevatedOrgIds }, isPersonal: { $ne: true } }] }
+      : { members: userId };
+  return Teams.find(filter);
 });
 
 Meteor.methods({
   async 'teams.list'() {
     const identity = await requireIdentity(this);
-    const teams = await Teams.find({ members: identity.userId }).fetchAsync();
+    const userId = identity.userId;
+
+    // Include all teams in orgs where this user is an owner or admin
+    const elevatedMemberships = await rawDb()
+      .collection('org_members')
+      .find({ userId, role: { $in: ['owner', 'admin'] } })
+      .toArray();
+    const elevatedOrgIds = elevatedMemberships.map((m) => m.orgId);
+    const teamFilter =
+      elevatedOrgIds.length > 0
+        ? { $or: [{ members: userId }, { orgId: { $in: elevatedOrgIds }, isPersonal: { $ne: true } }] }
+        : { members: userId };
+    const teams = await Teams.find(teamFilter).fetchAsync();
 
     const userPending = await TeamJoinRequests.rawCollection()
-      .find({ userId: identity.userId, status: 'pending' })
+      .find({ userId, status: 'pending' })
       .sort({ requestedAt: -1 })
       .toArray();
 
-    const adminTeamIds = teams.filter((t) => t.admins?.includes(identity.userId)).map((t) => {
-      const id = t._id?.toHexString ? t._id.toHexString() : String(t._id);
-      return id;
-    });
+    // Org owners/admins see pending join requests for all their teams
+    const adminTeamIds = teams
+      .filter((t) => {
+        const id = t._id?.toHexString ? t._id.toHexString() : String(t._id);
+        if (t.admins?.includes(userId)) return true;
+        return elevatedOrgIds.includes(t.orgId);
+      })
+      .map((t) => (t._id?.toHexString ? t._id.toHexString() : String(t._id)));
 
     let adminPending = [];
     if (adminTeamIds.length > 0) {


### PR DESCRIPTION
## Overview

Extends org admin authority to cover team management operations. Previously only org *owners* had elevated team access; org *admins* are now treated equally, and the code now checks both the modern `org_members` collection and the legacy `owners`/`admins` arrays on the org document.

## Changes

**`meteor-backend/server/org-helpers.js`**
- `isTeamAdminOrOrgOwner` now checks `org_members` for `owner` or `admin` role (not just owner)
- Falls back to legacy `org.owners` and `org.admins` arrays for pre-migration data

**`meteor-backend/server/permissions.js`**
- `resolveOrgRoleForTeam` gains a legacy fallback: checks `org.owners` / `org.admins` arrays when `org_members` has no matching record
- `buildTeamAbility` now grants `teamAdminIds` to org-elevated users (owner or admin), not just direct `team.admins` members

**`meteor-backend/server/teams.js`**
- `teams.byUser` publication (now `async`) surfaces all non-personal org teams for org owners/admins
- `teams.list` method applies the same elevated filter and includes join requests for all org teams the elevated user administers

## Acceptance Criteria

- [ ] Org admin can rename, delete, and manage members of any team in their org
- [ ] Org admin sees all org teams in the sidebar (not just teams they explicitly joined)
- [ ] Org admin sees pending join requests for all org teams
- [ ] Legacy orgs (with `owners`/`admins` arrays but no `org_members` records) still grant correct authority
- [ ] Org members without elevated role are unaffected